### PR TITLE
Add ability to force discriminator property to first in list

### DIFF
--- a/JsonSubTypes.Tests/DiscriminatorLocationTests.cs
+++ b/JsonSubTypes.Tests/DiscriminatorLocationTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+
+    class SimpleBase
+    {
+        public String Name { get; set; } 
+    }
+
+    class SimpleChildA : SimpleBase
+    {
+        public int Age { get; set; }
+    }
+
+    class SimpleChildB : SimpleBase
+    {
+        public int Height { get; set; }
+    }
+
+    [TestFixture]
+    public class DiscriminatorLocationTests
+    {
+        [Test]
+        public void CheckFirst()
+        {
+            var settings = new JsonSerializerSettings();
+            JsonConvert.DefaultSettings = () => settings;
+
+            settings.Converters.Add(JsonSubtypesConverterBuilder
+                .Of(typeof(SimpleBase), "type")
+                .SerializeDiscriminatorProperty(true)
+                .RegisterSubtype(typeof(SimpleChildA), "TypeA")
+                .RegisterSubtype(typeof(SimpleChildB), "TypeB")
+                .Build());
+
+
+            SimpleBase test_object = new SimpleChildA() { Name = "bob", Age = 12 };
+
+
+            var json_first = "{\"type\":\"TypeA\",\"Age\":12,\"Name\":\"bob\"}";
+
+            var result = JsonConvert.SerializeObject(test_object);
+            
+            Assert.AreEqual(json_first, result);
+        }
+
+        [Test]
+        public void checkDeserializeFirst()
+        {
+            var settings = new JsonSerializerSettings();
+            JsonConvert.DefaultSettings = () => settings;
+
+            settings.Converters.Add(JsonSubtypesConverterBuilder
+                .Of(typeof(SimpleBase), "type")
+                .SerializeDiscriminatorProperty(true)
+                .RegisterSubtype(typeof(SimpleChildA), "TypeA")
+                .RegisterSubtype(typeof(SimpleChildB), "TypeB")
+                .Build());
+
+
+            SimpleBase test_object = new SimpleChildB() { Name = "bob", Height = 36 };
+
+            var json_first = "{\"type\":\"TypeB\",\"Height\":36,\"Name\":\"bob\"}";
+
+            var result = JsonConvert.DeserializeObject<SimpleBase>(json_first);
+
+            Assert.IsInstanceOf(typeof(SimpleChildB), result);
+
+        }
+    }
+}

--- a/JsonSubTypes.Tests/DiscriminatorLocationTests.cs
+++ b/JsonSubTypes.Tests/DiscriminatorLocationTests.cs
@@ -50,7 +50,55 @@ namespace JsonSubTypes.Tests
         }
 
         [Test]
-        public void checkDeserializeFirst()
+        public void CheckDefaultLast()
+        {
+            var settings = new JsonSerializerSettings();
+            JsonConvert.DefaultSettings = () => settings;
+
+            settings.Converters.Add(JsonSubtypesConverterBuilder
+                .Of(typeof(SimpleBase), "type")
+                .SerializeDiscriminatorProperty()
+                .RegisterSubtype(typeof(SimpleChildA), "TypeA")
+                .RegisterSubtype(typeof(SimpleChildB), "TypeB")
+                .Build());
+
+
+            SimpleBase test_object = new SimpleChildA() { Name = "bob", Age = 12 };
+
+
+            var json_first = "{\"Age\":12,\"Name\":\"bob\",\"type\":\"TypeA\"}";
+
+            var result = JsonConvert.SerializeObject(test_object);
+
+            Assert.AreEqual(json_first, result);
+        }
+
+        [Test]
+        public void CheckExplicitLast()
+        {
+            var settings = new JsonSerializerSettings();
+            JsonConvert.DefaultSettings = () => settings;
+
+            settings.Converters.Add(JsonSubtypesConverterBuilder
+                .Of(typeof(SimpleBase), "type")
+                .SerializeDiscriminatorProperty(false)
+                .RegisterSubtype(typeof(SimpleChildA), "TypeA")
+                .RegisterSubtype(typeof(SimpleChildB), "TypeB")
+                .Build());
+
+
+            SimpleBase test_object = new SimpleChildA() { Name = "bob", Age = 12 };
+
+
+            var json_first = "{\"Age\":12,\"Name\":\"bob\",\"type\":\"TypeA\"}";
+
+            var result = JsonConvert.SerializeObject(test_object);
+
+            Assert.AreEqual(json_first, result);
+        }
+
+        [Test]
+        public void CheckDeserializeFirst()
         {
             var settings = new JsonSerializerSettings();
             JsonConvert.DefaultSettings = () => settings;

--- a/JsonSubTypes.Tests/JsonSubTypes.Tests.csproj
+++ b/JsonSubTypes.Tests/JsonSubTypes.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="BaseIsAnInterfaceTests.cs" />
     <Compile Include="DiscriminatorOfDifferentKindTests.cs" />
     <Compile Include="TypePropertyCase.cs" />
+    <Compile Include="DiscriminatorLocationTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JsonSubTypes\JsonSubTypes.csproj">

--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -100,8 +100,7 @@ namespace JsonSubTypes
             var typeMappingPropertyValue = JToken.FromObject(supportedType, serializer);
             if (_addDiscriminatorFirst)
             {
-                JProperty p = new JProperty(JsonDiscriminatorPropertyName, typeMappingPropertyValue);
-                jsonObj.AddFirst(p);
+                jsonObj.AddFirst(new JProperty(JsonDiscriminatorPropertyName, typeMappingPropertyValue));
             }
             else
             {

--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -39,7 +39,7 @@ namespace JsonSubTypes
         private bool _addDiscriminatorFirst;
 
         internal JsonSubtypesConverter(Type baseType, string discriminatorProperty,
-            Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst = false) : base(discriminatorProperty)
+            Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst) : base(discriminatorProperty)
         {
             _serializeDiscriminatorProperty = serializeDiscriminatorProperty;
             _baseType = baseType;

--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -36,15 +36,15 @@ namespace JsonSubTypes
 
         [ThreadStatic] private static bool _isInsideWrite;
         [ThreadStatic] private static bool _allowNextWrite;
-        private bool _addFirst;
+        private bool _addDiscriminatorFirst;
 
         internal JsonSubtypesConverter(Type baseType, string discriminatorProperty,
-            Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addFirst=false) : base(discriminatorProperty)
+            Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst = false) : base(discriminatorProperty)
         {
             _serializeDiscriminatorProperty = serializeDiscriminatorProperty;
             _baseType = baseType;
             _subTypeMapping = subTypeMapping;
-            _addFirst = addFirst;
+            _addDiscriminatorFirst = addDiscriminatorFirst;
             foreach (var type in _subTypeMapping)
             {
                 _supportedTypes.Add(type.Value, type.Key);
@@ -98,7 +98,7 @@ namespace JsonSubTypes
 
             var supportedType = _supportedTypes[value.GetType()];
             var typeMappingPropertyValue = JToken.FromObject(supportedType, serializer);
-            if (_addFirst)
+            if (_addDiscriminatorFirst)
             {
                 JProperty p = new JProperty(JsonDiscriminatorPropertyName, typeMappingPropertyValue);
                 jsonObj.AddFirst(p);

--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -36,13 +36,15 @@ namespace JsonSubTypes
 
         [ThreadStatic] private static bool _isInsideWrite;
         [ThreadStatic] private static bool _allowNextWrite;
+        private bool _addFirst;
 
         internal JsonSubtypesConverter(Type baseType, string discriminatorProperty,
-            Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty) : base(discriminatorProperty)
+            Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addFirst=false) : base(discriminatorProperty)
         {
             _serializeDiscriminatorProperty = serializeDiscriminatorProperty;
             _baseType = baseType;
             _subTypeMapping = subTypeMapping;
+            _addFirst = addFirst;
             foreach (var type in _subTypeMapping)
             {
                 _supportedTypes.Add(type.Value, type.Key);
@@ -96,8 +98,15 @@ namespace JsonSubTypes
 
             var supportedType = _supportedTypes[value.GetType()];
             var typeMappingPropertyValue = JToken.FromObject(supportedType, serializer);
-            jsonObj.Add(JsonDiscriminatorPropertyName, typeMappingPropertyValue);
-
+            if (_addFirst)
+            {
+                JProperty p = new JProperty(JsonDiscriminatorPropertyName, typeMappingPropertyValue);
+                jsonObj.AddFirst(p);
+            }
+            else
+            {
+                jsonObj.Add(JsonDiscriminatorPropertyName, typeMappingPropertyValue);
+            }
             jsonObj.WriteTo(writer);
         }
     }

--- a/JsonSubTypes/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesConverterBuilder.cs
@@ -22,7 +22,12 @@ namespace JsonSubTypes
             return customConverterBuilder;
         }
 
-        public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty(bool addDiscriminatorFirst = false)
+        public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty()
+        {
+            return SerializeDiscriminatorProperty(false);
+        }
+
+        public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty(bool addDiscriminatorFirst)
         {
             _serializeDiscriminatorProperty = true;
             _addDiscriminatorFirst = addDiscriminatorFirst;

--- a/JsonSubTypes/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesConverterBuilder.cs
@@ -10,6 +10,7 @@ namespace JsonSubTypes
         private string _discriminatorProperty;
         private readonly Dictionary<object, Type> _subTypeMapping = new Dictionary<object, Type>();
         private bool _serializeDiscriminatorProperty;
+        private bool _addDiscriminatorFirst;
 
         public static JsonSubtypesConverterBuilder Of(Type baseType, string discriminatorProperty)
         {
@@ -21,9 +22,10 @@ namespace JsonSubTypes
             return customConverterBuilder;
         }
 
-        public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty()
+        public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty(bool addDiscriminatorFirst = false)
         {
             _serializeDiscriminatorProperty = true;
+            _addDiscriminatorFirst = addDiscriminatorFirst;
             return this;
         }
 
@@ -35,7 +37,7 @@ namespace JsonSubTypes
 
         public JsonConverter Build()
         {
-            return new JsonSubtypesConverter(_baseType, _discriminatorProperty, _subTypeMapping, _serializeDiscriminatorProperty);
+            return new JsonSubtypesConverter(_baseType, _discriminatorProperty, _subTypeMapping, _serializeDiscriminatorProperty, _addDiscriminatorFirst);
         }
     }
 }


### PR DESCRIPTION
This is to enable the serializer to be compatible with the DataContractJsonSerializer built in to .NET if API's were already using that. This expects the discriminator to come first. 