### PR TITLE
Support for multiple discriminators on single type

### DIFF
--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -36,7 +36,7 @@ namespace JsonSubTypes
 
         [ThreadStatic] private static bool _isInsideWrite;
         [ThreadStatic] private static bool _allowNextWrite;
-        private bool _addDiscriminatorFirst;
+        private readonly bool _addDiscriminatorFirst;
 
         internal JsonSubtypesConverter(Type baseType, string discriminatorProperty,
             Dictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst) : base(discriminatorProperty)
@@ -47,7 +47,19 @@ namespace JsonSubTypes
             _addDiscriminatorFirst = addDiscriminatorFirst;
             foreach (var type in _subTypeMapping)
             {
-                _supportedTypes.Add(type.Value, type.Key);
+                if (_supportedTypes.ContainsKey(type.Value))
+                {
+                    if (_addDiscriminatorFirst)
+                    {
+                        throw new InvalidOperationException(
+                            "Multiple discriminators on single type are not supported " +
+                            "when discriminator serialization is enabled");
+                    }
+                }
+                else
+                {
+                    _supportedTypes.Add(type.Value, type.Key);
+                }
             }
         }
 

--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -49,7 +49,7 @@ namespace JsonSubTypes
             {
                 if (_supportedTypes.ContainsKey(type.Value))
                 {
-                    if (_addDiscriminatorFirst)
+                    if (_serializeDiscriminatorProperty)
                     {
                         throw new InvalidOperationException(
                             "Multiple discriminators on single type are not supported " +


### PR DESCRIPTION
This PR allows to add multiple discriminator values for single subtype which can cover all of discriminators. This is required for compound discriminators (tuples for example) and allows to write converters like this
```
JsonSubtypesConverterBuilder
    .Of(typeof(DeviceEvent), nameof(DeviceEvent.Discriminator))
    .RegisterSubtype(typeof(MetalDetectingAlert), (EventType.ALERT, DeviceType.METAL_DETECTOR))
    .RegisterSubtype(typeof(DeviceFailureWarning), (EventType.WARNING, DeviceType.METAL_DETECTOR))
    .RegisterSubtype(typeof(DeviceFailureWarning), (EventType.WARNING, DeviceType.CAMERA))
    .Build()
```