### PR TITLE
Clarify type name resolution rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var animal = JsonConvert.DeserializeObject<IAnimal>("{\"Kind\":\"Dog\",\"Breed\"
 Assert.AreEqual("Jack Russell Terrier", (animal as Dog)?.Breed);
 ```
 
-N.B.: Also works with fully qualified type name
+N.B.: This only works types in the same assembly as the base type/interface and either in the same namespace or with a fully qualified type name.
 
 ## DeserializeObject with custom type mapping
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var animal = JsonConvert.DeserializeObject<IAnimal>("{\"Kind\":\"Dog\",\"Breed\"
 Assert.AreEqual("Jack Russell Terrier", (animal as Dog)?.Breed);
 ```
 
-N.B.: This only works types in the same assembly as the base type/interface and either in the same namespace or with a fully qualified type name.
+N.B.: This only works for types in the same assembly as the base type/interface and either in the same namespace or with a fully qualified type name.
 
 ## DeserializeObject with custom type mapping
 


### PR DESCRIPTION
This might not be completely accurate. It's just based on my poking around in the code after spending a long time on a problem where JsonSubTypes didn't deserialize into subtypes in a sub-namespace of the base type.