### PR TITLE
Add version of builder methods with generic types for cleaner syntax.

### DIFF
--- a/JsonSubTypes.Tests/DynamicRegisterTests.cs
+++ b/JsonSubTypes.Tests/DynamicRegisterTests.cs
@@ -132,6 +132,26 @@ namespace JsonSubTypes.Tests
         }
 
         [Test]
+        public void RegisterWithGenericTypes()
+        {
+            var settings = new JsonSerializerSettings();
+            JsonConvert.DefaultSettings = () => settings;
+
+            settings.Converters.Add(JsonSubtypesConverterBuilder
+                .Of<Animal>("type")
+                .SerializeDiscriminatorProperty()
+                .RegisterSubtype<Cat>(AnimalType.Cat)
+                .RegisterSubtype<Dog>(AnimalType.Dog)
+                .Build());
+
+            var json = "{\"catLives\":6,\"age\":11,\"type\":2}";
+
+            var result = JsonConvert.SerializeObject(new Cat { Age = 11, Lives = 6 });
+
+            Assert.AreEqual(json, result);
+        }
+
+        [Test]
         public void UnregisteredTypeSerializeTest()
         {
             var settings = new JsonSerializerSettings();

--- a/JsonSubTypes.Tests/DynamicRegisterWithPropertyTests.cs
+++ b/JsonSubTypes.Tests/DynamicRegisterWithPropertyTests.cs
@@ -296,5 +296,24 @@ namespace JsonSubTypes.Tests
 
             Parallel.For(0, 100, index => test());
         }
+
+        [Test]
+        public void RegisterWithGeneric()
+        {
+            var settings = new JsonSerializerSettings();
+            JsonConvert.DefaultSettings = () => settings;
+
+            settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
+                .Of<Animal>()
+                .RegisterSubtypeWithProperty<Cat>("catLives")
+                .RegisterSubtypeWithProperty<Dog>("CanBark")
+                .Build());
+
+            var json = "{\"catLives\":11,}";
+
+            var result = JsonConvert.DeserializeObject<Animal>(json);
+
+            Assert.AreEqual(typeof(Cat), result.GetType());
+        }
     }
 }

--- a/JsonSubTypes/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesConverterBuilder.cs
@@ -44,6 +44,11 @@ namespace JsonSubTypes
             return customConverterBuilder;
         }
 
+        public static JsonSubtypesConverterBuilder Of<T>(string discriminatorProperty)
+        {
+            return Of(typeof(T), discriminatorProperty);
+        }
+
         public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty()
         {
             return SerializeDiscriminatorProperty(false);
@@ -62,10 +67,20 @@ namespace JsonSubTypes
             return this;
         }
 
+        public JsonSubtypesConverterBuilder RegisterSubtype<T>(object value)
+        {
+            return RegisterSubtype(typeof(T), value);
+        }
+
         public JsonSubtypesConverterBuilder SetFallbackSubtype(Type fallbackSubtype)
         {
             _fallbackSubtype = fallbackSubtype;
             return this;
+        }
+
+        public JsonSubtypesConverterBuilder SetFallbackSubtype<T>(object value)
+        {
+            return RegisterSubtype(typeof(T), value);
         }
 
         public JsonConverter Build()

--- a/JsonSubTypes/JsonSubtypesWithPropertyConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesWithPropertyConverterBuilder.cs
@@ -20,16 +20,31 @@ namespace JsonSubTypes
             return new JsonSubtypesWithPropertyConverterBuilder(baseType);
         }
 
+        public static JsonSubtypesWithPropertyConverterBuilder Of<T>()
+        {
+            return Of(typeof(T));
+        }
+
         public JsonSubtypesWithPropertyConverterBuilder RegisterSubtypeWithProperty(Type subtype, string jsonPropertyName)
         {
             _subTypeMapping.Add(jsonPropertyName, subtype);
             return this;
         }
 
+        public JsonSubtypesWithPropertyConverterBuilder RegisterSubtypeWithProperty<T>(string jsonPropertyName)
+        {
+            return RegisterSubtypeWithProperty(typeof(T), jsonPropertyName);
+        }
+
         public JsonSubtypesWithPropertyConverterBuilder SetFallbackSubtype(Type fallbackSubtype)
         {
             _fallbackSubtype = fallbackSubtype;
             return this;
+        }
+
+        public JsonSubtypesWithPropertyConverterBuilder SetFallbackSubtype<T>()
+        {
+            return SetFallbackSubtype(typeof(T));
         }
 
         public JsonConverter Build()

--- a/README.md
+++ b/README.md
@@ -99,12 +99,25 @@ public enum AnimalType
 ```
 
 ### Registration:
+
 ```csharp
 var settings = new JsonSerializerSettings();
 settings.Converters.Add(JsonSubtypesConverterBuilder
     .Of(typeof(Animal), "Type") // type property is only defined here
     .RegisterSubtype(typeof(Cat), AnimalType.Cat)
     .RegisterSubtype(typeof(Dog), AnimalType.Dog)
+    .SerializeDiscriminatorProperty() // ask to serialize the type property
+    .Build());
+```
+
+or using syntax with generics:
+
+```csharp
+var settings = new JsonSerializerSettings();
+settings.Converters.Add(JsonSubtypesConverterBuilder
+    .Of<Animal>("Type") // type property is only defined here
+    .RegisterSubtype<Cat>(AnimalType.Cat)
+    .RegisterSubtype<Dog>(AnimalType.Dog)
     .SerializeDiscriminatorProperty() // ask to serialize the type property
     .Build());
 ```
@@ -148,6 +161,8 @@ public class Artist : Person
 }
 ```
 
+or using syntax with generics:
+
 
 ```csharp
 string json = "[{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
@@ -168,6 +183,17 @@ settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
     .RegisterSubtypeWithProperty(typeof(Artist), "Skill")
     .Build());
 ```
+
+or
+
+```cs
+settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
+    .Of<Person>()
+    .RegisterSubtypeWithProperty<Employee>("JobTitle")
+    .RegisterSubtypeWithProperty<Artist>("Skill")
+    .Build());
+```
+
 
 ## A default class other than the base type can be defined
 


### PR DESCRIPTION
I propose adding to the builder methods with generica, as it provides slightly more readable fluent-like syntax compared to regular `typeof()`'s.

```cs
settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
    .Of<Person>()
    .RegisterSubtypeWithProperty<Employee>("JobTitle")
    .RegisterSubtypeWithProperty<Artist>("Skill")
    .Build());
```
