### PR TITLE
Improve handling a datetime field in a sub-type

### DIFF
--- a/JsonSubTypes.Tests/DatesTests.cs
+++ b/JsonSubTypes.Tests/DatesTests.cs
@@ -8,6 +8,7 @@ namespace JsonSubTypes.Tests
     public class DatesTest
     {
         [JsonConverter(typeof(JsonSubtypes), nameof(SubTypeClass.Discriminator))]
+        [JsonSubtypes.KnownSubType(typeof(SubTypeClass), "SubTypeClass")]
         public abstract class MainClass
         {
         }
@@ -22,13 +23,14 @@ namespace JsonSubTypes.Tests
         [Test]
         public void DeserializingSubTypeWithDateParsesCorrectly()
         {
-            var json = "{ \"Discriminator\": \"MainClass\", \"Date\": \"2020-06-28T00:00:00.00000+00:00\" }";
+            var json = "{ \"Discriminator\": \"SubTypeClass\", \"Date\": \"2020-06-28T00:00:00.00000+00:00\" }";
 
-            var obj = JsonConvert.DeserializeObject<SubTypeClass>(json);
+            var obj = JsonConvert.DeserializeObject<MainClass>(json);
 
             Assert.That(obj, Is.Not.Null);
-            Assert.That(obj.Date.HasValue, Is.True);
-            Assert.That(obj.Date.Value.Offset, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(obj, Is.InstanceOf<SubTypeClass>());
+            Assert.That(((SubTypeClass)obj).Date.HasValue, Is.True);
+            Assert.That(((SubTypeClass)obj).Date.Value.Offset, Is.EqualTo(TimeSpan.Zero));
         }
     }
 }

--- a/JsonSubTypes.Tests/DatesTests.cs
+++ b/JsonSubTypes.Tests/DatesTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+    [TestFixture]
+    public class DatesTest
+    {
+        [JsonConverter(typeof(JsonSubtypes), nameof(SubTypeClass.Discriminator))]
+        public abstract class MainClass
+        {
+        }
+
+        public class SubTypeClass : MainClass
+        {
+            public string Discriminator => "SubTypeClass";
+
+            public DateTimeOffset? Date { get; set; }
+        }
+
+        [Test]
+        public void DeserializingSubTypeWithDateParsesCorrectly()
+        {
+            var json = "{ \"Discriminator\": \"MainClass\", \"Date\": \"2020-06-28T00:00:00.00000+00:00\" }";
+
+            var obj = JsonConvert.DeserializeObject<SubTypeClass>(json);
+
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj.Date.HasValue, Is.True);
+            Assert.That(obj.Date.Value.Offset, Is.EqualTo(TimeSpan.Zero));
+        }
+    }
+}

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -201,7 +201,12 @@ namespace JsonSubTypes
 
         private object ReadObject(JsonReader reader, Type objectType, JsonSerializer serializer)
         {
+            // I would prefer to create a new reader, but can't work out how to
+            // This seems a reasonable alternative - https://github.com/JamesNK/Newtonsoft.Json/issues/1605#issuecomment-602673364
+            var savedDateParseSettings = reader.DateParseHandling;
+            reader.DateParseHandling = DateParseHandling.None;
             var jObject = JObject.Load(reader);
+            reader.DateParseHandling = savedDateParseSettings;
 
             var targetType = GetType(jObject, objectType, serializer) ?? objectType;
 


### PR DESCRIPTION
I ran into an issue where a subtype containing a date field was not deserialised correctly (it appeared that the timezone of the date was changed to my local machine's timezone).  This is an attempt at a fix based on a workaround I found for this issue, but would appreciate it if there was a better solution.