### PR TITLE
Fix deserialization of hierarchy with multiple levels

### DIFF
--- a/JsonSubTypes.Tests/MultipleHierarchyLevelsTests.cs
+++ b/JsonSubTypes.Tests/MultipleHierarchyLevelsTests.cs
@@ -84,13 +84,8 @@ namespace JsonSubTypes.Tests
 
             settings.Converters.Add(JsonSubtypesConverterBuilder
                 .Of(typeof(Payload), Payload.PAYLOAD_KIND)
-                .RegisterSubtype(typeof(Entertainment), PayloadDiscriminator.Entertainment)
+                .RegisterSubtype(typeof(Game), PayloadDiscriminator.GAME)
                 .RegisterSubtype(typeof(Com), PayloadDiscriminator.COM)
-                .Build());
-
-            settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
-                .Of(typeof(Entertainment))
-                .RegisterSubtypeWithProperty(typeof(Game), Game.GAME_KIND)
                 .Build());
 
             settings.Converters.Add(JsonSubtypesConverterBuilder
@@ -118,7 +113,7 @@ namespace JsonSubTypes.Tests
         public enum PayloadDiscriminator
         {
             COM = 0,
-            Entertainment = 1
+            GAME = 1
         }
 
         public enum GameDiscriminator
@@ -134,13 +129,9 @@ namespace JsonSubTypes.Tests
             [JsonProperty(PAYLOAD_KIND)] public abstract PayloadDiscriminator PayloadKind { get; }
         }
 
-        public abstract class Entertainment : Payload
+        public abstract class Game : Payload
         {
-            public override PayloadDiscriminator PayloadKind => PayloadDiscriminator.Entertainment;
-        }
-
-        public abstract class Game : Entertainment
-        {
+            public override PayloadDiscriminator PayloadKind => PayloadDiscriminator.GAME;
 
             public const string GAME_KIND = "$GameKind";
 

--- a/JsonSubTypes.Tests/MultipleHierarchyLevelsTests.cs
+++ b/JsonSubTypes.Tests/MultipleHierarchyLevelsTests.cs
@@ -84,8 +84,13 @@ namespace JsonSubTypes.Tests
 
             settings.Converters.Add(JsonSubtypesConverterBuilder
                 .Of(typeof(Payload), Payload.PAYLOAD_KIND)
-                .RegisterSubtype(typeof(Game), PayloadDiscriminator.GAME)
+                .RegisterSubtype(typeof(Entertainment), PayloadDiscriminator.Entertainment)
                 .RegisterSubtype(typeof(Com), PayloadDiscriminator.COM)
+                .Build());
+
+            settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
+                .Of(typeof(Entertainment))
+                .RegisterSubtypeWithProperty(typeof(Game), Game.GAME_KIND)
                 .Build());
 
             settings.Converters.Add(JsonSubtypesConverterBuilder
@@ -113,7 +118,7 @@ namespace JsonSubTypes.Tests
         public enum PayloadDiscriminator
         {
             COM = 0,
-            GAME = 1
+            Entertainment = 1
         }
 
         public enum GameDiscriminator
@@ -129,9 +134,13 @@ namespace JsonSubTypes.Tests
             [JsonProperty(PAYLOAD_KIND)] public abstract PayloadDiscriminator PayloadKind { get; }
         }
 
-        public abstract class Game : Payload
+        public abstract class Entertainment : Payload
         {
-            public override PayloadDiscriminator PayloadKind => PayloadDiscriminator.GAME;
+            public override PayloadDiscriminator PayloadKind => PayloadDiscriminator.Entertainment;
+        }
+
+        public abstract class Game : Entertainment
+        {
 
             public const string GAME_KIND = "$GameKind";
 

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -13,19 +13,19 @@ using System.Reflection;
 namespace JsonSubTypes
 {
     //  MIT License
-    //
+    //  
     //  Copyright (c) 2017 Emmanuel Counasse
-    //
+    //  
     //  Permission is hereby granted, free of charge, to any person obtaining a copy
     //  of this software and associated documentation files (the "Software"), to deal
     //  in the Software without restriction, including without limitation the rights
     //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     //  copies of the Software, and to permit persons to whom the Software is
     //  furnished to do so, subject to the following conditions:
-    //
+    //  
     //  The above copyright notice and this permission notice shall be included in all
     //  copies or substantial portions of the Software.
-    //
+    //  
     //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -248,7 +248,7 @@ namespace JsonSubTypes
             JsonSubtypes currentTypeResolver = this;
             var visitedTypes = new HashSet<Type> { targetType };
 
-            var jsonConverterCollection = serializer.Converters.OfType<JsonSubtypes>().ToList();
+            var jsonConverterCollection = serializer.Converters.OfType<JsonSubtypesByDiscriminatorValueConverter>().ToList();
             while (currentTypeResolver != null && currentTypeResolver != lastTypeResolver)
             {
                 targetType = currentTypeResolver.ResolveType(jObject, targetType, serializer);
@@ -265,7 +265,7 @@ namespace JsonSubTypes
             return targetType;
         }
 
-        private JsonSubtypes GetTypeResolver(TypeInfo targetType, IEnumerable<JsonSubtypes> jsonConverterCollection)
+        private JsonSubtypes GetTypeResolver(TypeInfo targetType, IEnumerable<JsonSubtypesByDiscriminatorValueConverter> jsonConverterCollection)
         {
             if (targetType == null)
             {

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -13,19 +13,19 @@ using System.Reflection;
 namespace JsonSubTypes
 {
     //  MIT License
-    //  
+    //
     //  Copyright (c) 2017 Emmanuel Counasse
-    //  
+    //
     //  Permission is hereby granted, free of charge, to any person obtaining a copy
     //  of this software and associated documentation files (the "Software"), to deal
     //  in the Software without restriction, including without limitation the rights
     //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     //  copies of the Software, and to permit persons to whom the Software is
     //  furnished to do so, subject to the following conditions:
-    //  
+    //
     //  The above copyright notice and this permission notice shall be included in all
     //  copies or substantial portions of the Software.
-    //  
+    //
     //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -248,7 +248,7 @@ namespace JsonSubTypes
             JsonSubtypes currentTypeResolver = this;
             var visitedTypes = new HashSet<Type> { targetType };
 
-            var jsonConverterCollection = serializer.Converters.OfType<JsonSubtypesByDiscriminatorValueConverter>().ToList();
+            var jsonConverterCollection = serializer.Converters.OfType<JsonSubtypes>().ToList();
             while (currentTypeResolver != null && currentTypeResolver != lastTypeResolver)
             {
                 targetType = currentTypeResolver.ResolveType(jObject, targetType, serializer);
@@ -265,7 +265,7 @@ namespace JsonSubTypes
             return targetType;
         }
 
-        private JsonSubtypes GetTypeResolver(TypeInfo targetType, IEnumerable<JsonSubtypesByDiscriminatorValueConverter> jsonConverterCollection)
+        private JsonSubtypes GetTypeResolver(TypeInfo targetType, IEnumerable<JsonSubtypes> jsonConverterCollection)
         {
             if (targetType == null)
             {


### PR DESCRIPTION
Fix deserialization in case of hierarchy with multiple levels that contains JsonSubtypesByPropertyPresenceConverter converter.
Added test for such case.