### PR TITLE
Added cache of type's attributes. 

### DIFF
--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -13,19 +13,19 @@ using System.Reflection;
 namespace JsonSubTypes
 {
     //  MIT License
-    //  
+    //
     //  Copyright (c) 2017 Emmanuel Counasse
-    //  
+    //
     //  Permission is hereby granted, free of charge, to any person obtaining a copy
     //  of this software and associated documentation files (the "Software"), to deal
     //  in the Software without restriction, including without limitation the rights
     //  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     //  copies of the Software, and to permit persons to whom the Software is
     //  furnished to do so, subject to the following conditions:
-    //  
+    //
     //  The above copyright notice and this permission notice shall be included in all
     //  copies or substantial portions of the Software.
-    //  
+    //
     //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     //  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     //  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -80,7 +80,6 @@ namespace JsonSubTypes
         [ThreadStatic] private static JsonReader _reader;
 
         private static readonly Dictionary<TypeInfo, IEnumerable<object>> _attributesCache = new Dictionary<TypeInfo, IEnumerable<object>>();
-
 
         public override bool CanRead
         {

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -86,6 +86,7 @@ namespace JsonSubTypes
         private static readonly Dictionary<TypeInfo, IEnumerable<object>> _attributesCache = new Dictionary<TypeInfo, IEnumerable<object>>();
 #else
         private static readonly ConcurrentDictionary<TypeInfo, IEnumerable<object>> _attributesCache = new ConcurrentDictionary<TypeInfo, IEnumerable<object>>();
+        private static readonly Func<TypeInfo, IEnumerable<object>> _getCustomAttributes = ti => ti.GetCustomAttributes(false);
 #endif
 
         public override bool CanRead
@@ -470,7 +471,7 @@ namespace JsonSubTypes
 
             return res;
 #else
-            return _attributesCache.GetOrAdd(typeInfo, ti => ti.GetCustomAttributes(false));
+            return _attributesCache.GetOrAdd(typeInfo, _getCustomAttributes);
 #endif
         }
 

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -457,19 +457,16 @@ namespace JsonSubTypes
         private static IEnumerable<object> GetAttributes(TypeInfo typeInfo)
         {
 #if NET35
-            if (_attributesCache.TryGetValue(typeInfo, out var res))
-                return res;
-
             lock (_attributesCache)
             {
-                if (!_attributesCache.TryGetValue(typeInfo, out res))
-                {
-                    res = typeInfo.GetCustomAttributes(false);
-                    _attributesCache.Add(typeInfo, res);
-                }
-            }
+                if (_attributesCache.TryGetValue(typeInfo, out var res))
+                   return res;
 
-            return res;
+                res = typeInfo.GetCustomAttributes(false);
+                _attributesCache.Add(typeInfo, res);
+
+                return res;
+            }
 #else
             return _attributesCache.GetOrAdd(typeInfo, _getCustomAttributes);
 #endif

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -470,7 +470,7 @@ namespace JsonSubTypes
 
             return res;
 #else
-            return _attributesCache.GetOrAdd(typeInfo, typeInfo.GetCustomAttributes(false));
+            return _attributesCache.GetOrAdd(typeInfo, ti => ti.GetCustomAttributes(false));
 #endif
         }
 


### PR DESCRIPTION
Added cache of type's attributes. This significantly improves performance in case of deserialization of a large amount of data. In my project it decreased time of deserialization of 300k objects from 27s to 7s.
Used double-checked lock to prevent cоncurrency issues. Didn't use ConcurrentDictionary because there is no such in net3.5.
