### PR TITLE
added support for cross-assembly discriminator properties 

### DIFF
--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -380,6 +380,11 @@ namespace JsonSubTypes
                 var searchLocation = parentTypeFullName.Substring(0, parentTypeFullName.Length - parentType.Name.Length);
                 typeByName = insideAssembly.GetType(searchLocation + typeName, false, true);
             }
+            
+            if (parentTypeFullName != null && typeByName == null)
+            {
+                typeByName = Type.GetType(typeName);
+            }
 
             var typeByNameInfo = ToTypeInfo(typeByName);
             if (typeByNameInfo != null && parentType.IsAssignableFrom(typeByNameInfo))


### PR DESCRIPTION
... that use fully qualified names

This simple patch allows for using JsonSubTypes with fully qualified or assembly qualified names to access cross-assembly subtypes via discriminator properties.  

This also allows to use fully qualified names at all - beforhand they could not be found even if in same assembly.

Example baseclass usage that now can be derived in another assembly:

    [JsonConverter(typeof(JsonSubtypes), "JSONType")]
    public class MyBaseClass
    {
        public string JSONType { get { return this.GetType().AssemblyQualifiedName; } }
    }

