### PR TITLE
Copy MaxDepth when creating internal JObjectReader

### DIFF
--- a/JsonSubTypes.Tests.Net35/App.config
+++ b/JsonSubTypes.Tests.Net35/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/JsonSubTypes.Tests.Net35/JsonSubTypes.Tests.Net35.csproj
+++ b/JsonSubTypes.Tests.Net35/JsonSubTypes.Tests.Net35.csproj
@@ -15,7 +15,7 @@
     <DefineConstants>TRACE;NET35</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="TaskParallelLibrary" Version="1.0.2856.0" />
   </ItemGroup>

--- a/JsonSubTypes.Tests/App.config
+++ b/JsonSubTypes.Tests/App.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/JsonSubTypes.Tests/DeeplyNestedDeserializationTests.cs
+++ b/JsonSubTypes.Tests/DeeplyNestedDeserializationTests.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+    [TestFixture]
+    public class DeeplyNestedDeserializationTests
+    {
+        [JsonConverter(typeof(JsonSubtypes), nameof(SubTypeClass.Discriminator))]
+        [JsonSubtypes.KnownSubType(typeof(SubTypeClass), "SubTypeClass")]
+        public abstract class MainClass
+        {
+        }
+
+        public class SubTypeClass : MainClass
+        {
+            public string Discriminator => "SubTypeClass";
+
+            public MainClass Child { get; set; }
+        }
+
+        [Test]
+        public void DeserializingDeeplyNestedJsonWithHighMaxDepthParsesCorrectly()
+        {
+            var root = new SubTypeClass();
+
+            var current = root;
+            for (var i = 0; i < 64; i++)
+            {
+                var child = new SubTypeClass();
+                current.Child = child;
+                current = child;
+            }
+
+            var json = JsonConvert.SerializeObject(root);
+
+            var obj = JsonConvert.DeserializeObject<MainClass>(json, new JsonSerializerSettings { MaxDepth = 65 });
+            Assert.That(obj, Is.Not.Null);
+        }
+    }
+}

--- a/JsonSubTypes.Tests/JsonSubTypes.Tests.csproj
+++ b/JsonSubTypes.Tests/JsonSubTypes.Tests.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
   </ItemGroup>
   <ItemGroup>

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -233,6 +233,7 @@ namespace JsonSubTypes
             jObjectReader.FloatParseHandling = reader.FloatParseHandling;
             jObjectReader.DateFormatString = reader.DateFormatString;
             jObjectReader.DateParseHandling = reader.DateParseHandling;
+            jObjectReader.MaxDepth = reader.MaxDepth;
             return jObjectReader;
         }
 

--- a/JsonSubTypes/packages.config
+++ b/JsonSubTypes/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net47" allowedVersions="[10.0.0, 13.0.0)" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net47" allowedVersions="[10.0.0, 14.0.0)" />
 </packages>


### PR DESCRIPTION
Fixes #136. Also upgrades test projects to Newtonsoft.Json 13.0.1 to properly test fix.