### PR TITLE
Support OR condition on multiple properties for one type

### DIFF
--- a/JsonSubTypes.Tests/DemoKnownSubTypeWithProperties.cs
+++ b/JsonSubTypes.Tests/DemoKnownSubTypeWithProperties.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+    [TestFixture]
+    public class DemoKnownSubTypeWithMultipleProperties
+    {
+        [JsonConverter(typeof(JsonSubtypes))]
+        [JsonSubtypes.KnownSubTypeWithProperty(typeof(Employee), "JobTitle")]
+        [JsonSubtypes.KnownSubTypeWithProperty(typeof(Employee), "Department")]
+        [JsonSubtypes.KnownSubTypeWithProperty(typeof(Artist), "Skill")]
+        public class Person
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+
+        public class Employee : Person
+        {
+            public string Department { get; set; }
+            public string JobTitle { get; set; }
+        }
+
+        public class Artist : Person
+        {
+            public string Skill { get; set; }
+        }
+
+        [Test]
+        public void Demo()
+        {
+            string json = "[{\"Department\":\"Department1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"Skill\":\"Painter\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}]";
+
+
+            var persons = JsonConvert.DeserializeObject<ICollection<Person>>(json);
+            Assert.AreEqual("Painter", (persons.Last() as Artist)?.Skill);
+        }
+
+        [Test]
+        public void DemoDifferentCase()
+        {
+            string json = "[{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"skill\"" +
+                          ":\"Painter\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}]";
+
+
+            var persons = JsonConvert.DeserializeObject<ICollection<Person>>(json);
+            Assert.AreEqual("Painter", (persons.Last() as Artist)?.Skill);
+        }
+
+        [Test]
+        public void FallBackToPArentWhenNotFound()
+        {
+            string json = "[{\"Skl.\":\"Painter\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}]";
+
+            var persons = JsonConvert.DeserializeObject<ICollection<Person>>(json);
+            Assert.AreEqual(typeof(Person), persons.First().GetType());
+        }
+
+        [Test]
+        public void ThrowIfManyMatches()
+        {
+            string json = "{\r\n  \"Name\": \"Foo\",\r\n  \"Skill\": \"A\",\r\n  \"JobTitle\": \"B\"\r\n}";
+
+            var jsonSerializationException = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<Person>(json));
+            Assert.AreEqual("Ambiguous type resolution, expected only one type but got: JsonSubTypes.Tests.DemoKnownSubTypeWithMultipleProperties+Employee, JsonSubTypes.Tests.DemoKnownSubTypeWithMultipleProperties+Artist", jsonSerializationException.Message);
+        }
+    }
+}

--- a/JsonSubTypes.Tests/JsonSubTypes.Tests.csproj
+++ b/JsonSubTypes.Tests/JsonSubTypes.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JsonSubTypes\JsonSubTypes.csproj" />

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -319,7 +319,7 @@ namespace JsonSubTypes
                 return types[0];
             }
 
-            if (types.Length > 1)
+            if (types.Distinct().Count() > 1)
             {
                 throw new JsonSerializationException("Ambiguous type resolution, expected only one type but got: " + String.Join(", ", types.Select(t => t.FullName).ToArray()));
             }

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -314,12 +314,14 @@ namespace JsonSubTypes
                 .Where(type => type != null)
                 .ToArray();
 
-            if (types.Length == 1)
+            var distinctTypes = types.Distinct().Count();
+
+            if (distinctTypes == 1)
             {
                 return types[0];
             }
 
-            if (types.Distinct().Count() > 1)
+            if (distinctTypes > 1)
             {
                 throw new JsonSerializationException("Ambiguous type resolution, expected only one type but got: " + String.Join(", ", types.Select(t => t.FullName).ToArray()));
             }


### PR DESCRIPTION
Allow a type to be instantiated if one or more properties are present. eg:

```cs 
    [JsonConverter(typeof(JsonSubtypes))]
    [JsonSubtypes.FallBackSubType(typeof(Dog))]
    [JsonSubtypes.KnownSubTypeWithProperty(typeof(Cat), "MeowSoundVolume")]
    [JsonSubtypes.KnownSubTypeWithProperty(typeof(Cat), "PurrSoundIntensity")]
```
