### PR TITLE
Fix datetime deserialization

### DIFF
--- a/JsonSubTypes.Tests/DatesTests.cs
+++ b/JsonSubTypes.Tests/DatesTests.cs
@@ -19,6 +19,20 @@ namespace JsonSubTypes.Tests
 
             public DateTimeOffset? DateTimeOffset { get; set; }
             public DateTime? DateTime { get; set; }
+            public DatesClass DatesClass { get; set; }
+        }
+
+        public class NoSubTypeClass
+        {
+            public DateTimeOffset? DateTimeOffset { get; set; }
+            public DateTime? DateTime { get; set; }
+            public DatesClass DatesClass { get; set; }
+        }
+
+        public class DatesClass
+        {
+            public DateTimeOffset? DateTimeOffset { get; set; }
+            public DateTime? DateTime { get; set; }
         }
 
         [Test]
@@ -37,6 +51,173 @@ namespace JsonSubTypes.Tests
             Assert.That(((SubTypeClass)obj).DateTimeOffset.Value.Offset, Is.EqualTo(TimeSpan.Zero));
             Assert.That(((SubTypeClass)obj).DateTime.HasValue, Is.True);
             Assert.That(((SubTypeClass)obj).DateTime.Value, Is.EqualTo(new DateTime(2020,6,28,0,0,0,0)));
+        }
+
+        [Test]
+        public void DeserializingSubTypeWithNoOffsetDateParsesCorrectly()
+        {
+            RunDeserializeSubTypeWithOffsetDateTest(new TimeSpan(0, 0, 0));
+        }
+
+        [Test]
+        public void DeserializingSubTypeWithNegativeOffsetDateParsesCorrectly()
+        {
+            RunDeserializeSubTypeWithOffsetDateTest(new TimeSpan(-4, 0, 0));
+        }
+
+        [Test]
+        public void DeserializingSubTypeWithPositiveOffsetDateParsesCorrectly()
+        {
+            RunDeserializeSubTypeWithOffsetDateTest(new TimeSpan(6, 0, 0));
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithSerializerSettingDefaults()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, settings.DateParseHandling, settings.DateTimeZoneHandling);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeAndDateTimeZoneHandlingUtc()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTime, DateTimeZoneHandling.Utc);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeAndDateTimeZoneHandlingLocal()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTime, DateTimeZoneHandling.Local);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeAndDateTimeZoneHandlingRoundtripKind()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTime, DateTimeZoneHandling.RoundtripKind);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeAndDateTimeZoneHandlingUnspecified()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTime, DateTimeZoneHandling.Unspecified);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeOffsetAndDateTimeZoneHandlingUtc()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTimeOffset, DateTimeZoneHandling.Utc);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeOffsetAndDateTimeZoneHandlingLocal()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTimeOffset, DateTimeZoneHandling.Local);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeOffsetAndDateTimeZoneHandlingRoundtripKind()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTimeOffset, DateTimeZoneHandling.RoundtripKind);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingDateTimeOffsetAndDateTimeZoneHandlingUnspecified()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.DateTimeOffset, DateTimeZoneHandling.Unspecified);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingNoneAndDateTimeZoneHandlingUtc()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.None, DateTimeZoneHandling.Utc);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingNoneAndDateTimeZoneHandlingLocal()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.None, DateTimeZoneHandling.Local);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingNoneAndDateTimeZoneHandlingRoundtripKind()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.None, DateTimeZoneHandling.RoundtripKind);
+        }
+
+        [Test]
+        public void DeserializingSubTypeMatchesStockDeserializationWithDateParseHandlingNoneAndDateTimeZoneHandlingUnspecified()
+        {
+            string dateTimeAsString = "2020-06-28T00:00:00.00000-04:00";
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            RunSubtypeMatchesStockDDeserializationTest(dateTimeAsString, DateParseHandling.None, DateTimeZoneHandling.Unspecified);
+        }
+
+        private void RunSubtypeMatchesStockDDeserializationTest(string dateTime, DateParseHandling dateParseHandling, DateTimeZoneHandling dateTimeZoneHandling)
+        {
+            var json = $" {{ \"Discriminator\": \"SubTypeClass\", \"DateTime\": \"{dateTime}\", \"DateTimeOffset\": \"{dateTime}\", \"DatesClass\": {{ \"DateTime\": \"{dateTime}\", \"DateTimeOffset\": \"{dateTime}\" }} }}";
+            var jsonSerializerSettings = new JsonSerializerSettings()
+            {
+                DateParseHandling = dateParseHandling,
+                DateTimeZoneHandling = dateTimeZoneHandling
+            };
+
+            // stock Newtonsoft Deserialization
+            var stock = JsonConvert.DeserializeObject<NoSubTypeClass>(json, jsonSerializerSettings);
+            // JsonSubtypes Deserialization
+            var subtype = JsonConvert.DeserializeObject<MainClass>(json, jsonSerializerSettings);
+
+            Assert.IsNotNull(stock);
+            Assert.IsNotNull(subtype);
+            Assert.IsInstanceOf(typeof(NoSubTypeClass), stock);
+            Assert.IsInstanceOf(typeof(SubTypeClass), subtype);
+            Assert.IsNotNull(stock.DatesClass);
+            Assert.IsNotNull(((SubTypeClass)subtype).DatesClass);
+            Assert.IsInstanceOf(typeof(DatesClass), stock.DatesClass);
+            Assert.IsInstanceOf(typeof(DatesClass), ((SubTypeClass)subtype).DatesClass);
+            // Compare ToString values as AreEqual on DateTimeOffset will use offsets when determining equivalence
+            Assert.AreEqual(stock.DateTime.ToString(), ((SubTypeClass)subtype).DateTime.ToString(), $"DateTime With {dateParseHandling} & {dateTimeZoneHandling}");
+            Assert.AreEqual(stock.DateTimeOffset.ToString(), ((SubTypeClass)subtype).DateTimeOffset.ToString(), $"DateTimeOffset With {dateParseHandling} & {dateTimeZoneHandling}");
+            Assert.AreEqual(stock.DatesClass.DateTime.ToString(), ((SubTypeClass)subtype).DatesClass.DateTime.ToString(), $"DatesClass.DateTime With {dateParseHandling} & {dateTimeZoneHandling}");
+            Assert.AreEqual(stock.DatesClass.DateTimeOffset.ToString(), ((SubTypeClass)subtype).DatesClass.DateTimeOffset.ToString(), $"DatesClass.DateTime With {dateParseHandling} & {dateTimeZoneHandling}");
+        }
+
+        private void RunDeserializeSubTypeWithOffsetDateTest(TimeSpan offset)
+        {
+            DateTimeOffset dto = new DateTimeOffset(2020, 06, 28, 0, 0, 0, offset);
+            DateTimeOffset local = dto.ToLocalTime();
+            var json = $"{{ \"Discriminator\": \"SubTypeClass\", \"DateTime\": \"{dto:O}\", \"DateTimeOffset\": \"{dto:O}\" }}";
+
+            var obj = JsonConvert.DeserializeObject<MainClass>(json);
+
+            Assert.That(obj, Is.Not.Null);
+            Assert.That(obj, Is.InstanceOf<SubTypeClass>());
+            Assert.That(((SubTypeClass)obj).DateTimeOffset.HasValue, Is.True);
+            Assert.That(((SubTypeClass)obj).DateTimeOffset.Value.Offset, Is.EqualTo(offset));
+            Assert.That(((SubTypeClass)obj).DateTime.HasValue, Is.True);
+            Assert.That(((SubTypeClass)obj).DateTime.Value.ToString(), Is.EqualTo(local.DateTime.ToString()));
         }
     }
 }

--- a/JsonSubTypes.Tests/DatesTests.cs
+++ b/JsonSubTypes.Tests/DatesTests.cs
@@ -36,24 +36,6 @@ namespace JsonSubTypes.Tests
         }
 
         [Test]
-        public void DeserializingSubTypeWithDateParsesCorrectly()
-        {
-            var json = "{ \"Discriminator\": \"SubTypeClass\", \"DateTime\": \"2020-06-28T00:00:00.00000+00:00\", \"DateTimeOffset\": \"2020-06-28T00:00:00.00000+00:00\" }";
-
-            var obj = JsonConvert.DeserializeObject<MainClass>(json, new JsonSerializerSettings
-            {
-                DateParseHandling = DateParseHandling.DateTimeOffset
-            });
-
-            Assert.That(obj, Is.Not.Null);
-            Assert.That(obj, Is.InstanceOf<SubTypeClass>());
-            Assert.That(((SubTypeClass)obj).DateTimeOffset.HasValue, Is.True);
-            Assert.That(((SubTypeClass)obj).DateTimeOffset.Value.Offset, Is.EqualTo(TimeSpan.Zero));
-            Assert.That(((SubTypeClass)obj).DateTime.HasValue, Is.True);
-            Assert.That(((SubTypeClass)obj).DateTime.Value, Is.EqualTo(new DateTime(2020,6,28,0,0,0,0)));
-        }
-
-        [Test]
         public void DeserializingSubTypeWithNoOffsetDateParsesCorrectly()
         {
             RunDeserializeSubTypeWithOffsetDateTest(new TimeSpan(0, 0, 0));

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -214,7 +214,10 @@ namespace JsonSubTypes
 
         private object ReadObject(JsonReader reader, Type objectType, JsonSerializer serializer)
         {
+            var prevDateParseHandling = reader.DateParseHandling;
+            reader.DateParseHandling = DateParseHandling.None;
             var jObject = JObject.Load(reader);
+            reader.DateParseHandling = prevDateParseHandling;
 
             var targetType = GetType(jObject, objectType, serializer) ?? objectType;
 


### PR DESCRIPTION
resolves #166

Ensures that properties that "look like" datetime/datetimeoffset are passed through step 1 of deserialization (to JObject) to ensure that the raw value is deserialized to the known target type property type.

Running the new tests in this [commit](https://github.com/manuc66/JsonSubTypes/pull/167/commits/319d380dfbfb9ba978ccdb96f57aec49dd6e0919) against 2.0.1 result in 12 of 17 failures.

As mentioned in [#120](https://github.com/manuc66/JsonSubTypes/issues/120#issuecomment-986953126), with this change, jsonextensiondata will be `string` for datetime/datetimeoffset fields as I could not find a way to avoid this short of reworking the way JsonSubtypes works (e.g., reparsing json entirely which would have perf impact).  A workaround for this limitation, although far from ideal due to perf impact, would be to serialize/deserialize the extension data in the OnDeserialized event similar to

```csharp
  public class SubTypeOrder : OrderBase
  {
      [JsonExtensionData]
      private IDictionary<string, JToken> _extensionData;

      [OnDeserialized]
      private void OnDeserialized(StreamingContext context)
      {
          var json = JsonConvert.SerializeObject(_extensionData);
          _extensionData = JsonConvert.DeserializeObject<IDictionary<string, JToken>>(json);
      }
  }
```

If this is merged, would recommend this be considered a breaking change and major version incremented (v1.8 likely should have been 2.0 since it changed the behavior, etc.).