### PR TITLE
Declare known baseType(s) instead of subTypes

### DIFF
--- a/JsonSubTypes.Tests/AbstractBaseClassDiscriminatorTests.cs
+++ b/JsonSubTypes.Tests/AbstractBaseClassDiscriminatorTests.cs
@@ -57,4 +57,37 @@ namespace JsonSubTypes.Tests
                 exception.Message);
         }
     }
+
+    [TestFixture]
+    public class KnownBaseType_AbstractBaseClassDiscriminatorTests
+    {
+        [JsonConverter(typeof(JsonSubtypes), "Discriminator")]
+        [JsonSubtypes.KnownBaseType(typeof(CC), "D")]
+        public abstract class AA
+        {
+        }
+
+        [JsonConverter(typeof(JsonSubtypes), "Discriminator")]
+        [JsonSubtypes.KnownBaseType(typeof(AA), "D")]
+        public abstract class BB
+        {
+        }
+
+        [JsonConverter(typeof(JsonSubtypes), "Discriminator")]
+        [JsonSubtypes.KnownBaseType(typeof(BB), "D")]
+        public abstract class CC
+        {
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void DeserializingWithAbstractClassCircleThrows()
+        {
+            var exception = Assert.Throws<JsonSerializationException>(() =>
+                JsonConvert.DeserializeObject<AA>("{\"Discriminator\":\"D\"}"));
+            Assert.AreEqual(
+                "Could not create an instance of type JsonSubTypes.Tests.KnownBaseType_AbstractBaseClassDiscriminatorTests+AA. Type is an interface or abstract class and cannot be instantiated. Path 'Discriminator', line 1, position 17.",
+                exception.Message);
+        }
+    }
 }

--- a/JsonSubTypes.Tests/BaseIsAnInterfaceTests.cs
+++ b/JsonSubTypes.Tests/BaseIsAnInterfaceTests.cs
@@ -54,4 +54,54 @@ namespace JsonSubTypes.Tests
             Assert.AreEqual("Could not create an instance of type JsonSubTypes.Tests.BaseIsAnInterfaceTests+IAnimal. Type is an interface or abstract class and cannot be instantiated. Path 'Sound', line 1, position 9.", exception.Message);
         }
     }
+
+    [TestFixture]
+    public class KnownBaseType_BaseIsAnInterfaceTests
+    {
+        [JsonConverter(typeof(JsonSubtypes), "Sound")]
+        public interface IAnimal
+        {
+            string Sound { get; }
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(IAnimal), "Bark")]
+        public class Dog : IAnimal
+        {
+            public string Sound { get; } = "Bark";
+            public string Breed { get; set; }
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(IAnimal), "Meow")]
+        public class Cat : IAnimal
+        {
+            public string Sound { get; } = "Meow";
+            public bool Declawed { get; set; }
+        }
+
+        [Test]
+        public void Test()
+        {
+            var animal = JsonConvert.DeserializeObject<IAnimal>("{\"Sound\":\"Bark\",\"Breed\":\"Jack Russell Terrier\"}");
+            Assert.AreEqual("Jack Russell Terrier", (animal as Dog)?.Breed);
+        }
+
+        [Test]
+        public void ConcurrentThreadTest()
+        {
+            Action test = () =>
+            {
+                var animal = JsonConvert.DeserializeObject<IAnimal>("{\"Sound\":\"Bark\",\"Breed\":\"Jack Russell Terrier\"}");
+                Assert.AreEqual("Jack Russell Terrier", (animal as Dog)?.Breed);
+            };
+
+            Parallel.For(0, 100, index => test());
+        }
+
+        [Test]
+        public void UnknownMappingFails()
+        {
+            var exception = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<IAnimal>("{\"Sound\":\"Scream\"}"));
+            Assert.AreEqual("Could not create an instance of type JsonSubTypes.Tests.KnownBaseType_BaseIsAnInterfaceTests+IAnimal. Type is an interface or abstract class and cannot be instantiated. Path 'Sound', line 1, position 9.", exception.Message);
+        }
+    }
 }

--- a/JsonSubTypes.Tests/DeeplyNestedDeserializationTests.cs
+++ b/JsonSubTypes.Tests/DeeplyNestedDeserializationTests.cs
@@ -38,4 +38,40 @@ namespace JsonSubTypes.Tests
             Assert.That(obj, Is.Not.Null);
         }
     }
+
+    [TestFixture]
+    public class KnownBaseType_DeeplyNestedDeserializationTests
+    {
+        [JsonConverter(typeof(JsonSubtypes), nameof(SubTypeClass.Discriminator))]
+        public abstract class MainClass
+        {
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(MainClass), "SubTypeClass")]
+        public class SubTypeClass : MainClass
+        {
+            public string Discriminator => "SubTypeClass";
+
+            public MainClass Child { get; set; }
+        }
+
+        [Test]
+        public void DeserializingDeeplyNestedJsonWithHighMaxDepthParsesCorrectly()
+        {
+            var root = new SubTypeClass();
+
+            var current = root;
+            for (var i = 0; i < 64; i++)
+            {
+                var child = new SubTypeClass();
+                current.Child = child;
+                current = child;
+            }
+
+            var json = JsonConvert.SerializeObject(root);
+
+            var obj = JsonConvert.DeserializeObject<MainClass>(json, new JsonSerializerSettings { MaxDepth = 65 });
+            Assert.That(obj, Is.Not.Null);
+        }
+    }
 }

--- a/JsonSubTypes.Tests/DemoAlternativeTypePropertyNameTests.cs
+++ b/JsonSubTypes.Tests/DemoAlternativeTypePropertyNameTests.cs
@@ -253,6 +253,46 @@ namespace JsonSubTypes.Tests
                 Assert.AreEqual("Octopus", (animal as UnknownAnimal)?.Kind);
             }
         }
+
+        [TestFixture]
+        public class KnownBaseType_DemoAlternativeTypePropertyNameTests
+        {
+            [JsonConverter(typeof(JsonSubtypes), "Kind")]
+            [JsonSubtypes.FallBackSubType(typeof(UnknownAnimal))]
+            public interface IAnimal
+            {
+                string Kind { get; }
+            }
+
+            public class UnknownAnimal : IAnimal
+            {
+                public string Kind { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(IAnimal), null)]
+            public class Dog : IAnimal
+            {
+                public string Kind { get; } = null;
+                public string Breed { get; set; }
+            }
+
+            [Test]
+            public void Demo()
+            {
+                var animal =
+                    JsonConvert.DeserializeObject<IAnimal>(
+                        "{\"Kind\":null,\"Breed\":\"Jack Russell Terrier\"}");
+                Assert.AreEqual("Jack Russell Terrier", (animal as Dog)?.Breed);
+            }
+
+            [Test]
+            public void WhenNoMappingPossible()
+            {
+                var animal = JsonConvert.DeserializeObject<IAnimal>("{\"Kind\":\"Octopus\",\"Specie\":\"Octopus tetricus\"}");
+
+                Assert.AreEqual("Octopus", (animal as UnknownAnimal)?.Kind);
+            }
+        }
     }
 }
 

--- a/JsonSubTypes.Tests/DemoCustomSubclassMappingTests.cs
+++ b/JsonSubTypes.Tests/DemoCustomSubclassMappingTests.cs
@@ -37,4 +37,39 @@ namespace JsonSubTypes.Tests
             Assert.AreEqual(true, (animal as Cat)?.Declawed);
         }
     }
+
+    [TestFixture]
+    public class KnownBaseType_DemoCustomSubclassMappingTests
+    {
+        [JsonConverter(typeof(JsonSubtypes), "Sound")]
+        public class Animal
+        {
+            public virtual string Sound { get; }
+            public string Color { get; set; }
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(Animal), "Bark")]
+        public class Dog : Animal
+        {
+            public override string Sound { get; } = "Bark";
+            public string Breed { get; set; }
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(Animal), "Meow")]
+        public class Cat : Animal
+        {
+            public override string Sound { get; } = "Meow";
+            public bool Declawed { get; set; }
+        }
+
+        [Test]
+        public void Demo()
+        {
+            var animal = JsonConvert.DeserializeObject<Animal>("{\"Sound\":\"Bark\",\"Breed\":\"Jack Russell Terrier\"}");
+            Assert.AreEqual("Jack Russell Terrier", (animal as Dog)?.Breed);
+
+            animal = JsonConvert.DeserializeObject<Animal>("{\"Sound\":\"Meow\",\"Declawed\":\"true\"}");
+            Assert.AreEqual(true, (animal as Cat)?.Declawed);
+        }
+    }
 }

--- a/JsonSubTypes.Tests/DemoKnownSubTypeWithProperty.cs
+++ b/JsonSubTypes.Tests/DemoKnownSubTypeWithProperty.cs
@@ -71,4 +71,71 @@ namespace JsonSubTypes.Tests
             Assert.AreEqual("Ambiguous type resolution, expected only one type but got: JsonSubTypes.Tests.DemoKnownSubTypeWithProperty+Employee, JsonSubTypes.Tests.DemoKnownSubTypeWithProperty+Artist", jsonSerializationException.Message);
         }
     }
+
+    [TestFixture]
+    public class KnownBaseType_DemoKnownSubTypeWithProperty
+    {
+        [JsonConverter(typeof(JsonSubtypes))]
+        public class Person
+        {
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+        }
+
+        [JsonSubtypes.KnownBaseTypeWithProperty(typeof(Person), "JobTitle")]
+        public class Employee : Person
+        {
+            public string Department { get; set; }
+            public string JobTitle { get; set; }
+        }
+
+        [JsonSubtypes.KnownBaseTypeWithProperty(typeof(Person), "Skill")]
+        public class Artist : Person
+        {
+            public string Skill { get; set; }
+        }
+
+        [Test]
+        public void Demo()
+        {
+            string json = "[{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"Skill\":\"Painter\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}]";
+
+
+            var persons = JsonConvert.DeserializeObject<ICollection<Person>>(json);
+            Assert.AreEqual("Painter", (persons.Last() as Artist)?.Skill);
+        }
+
+        [Test]
+        public void DemoDifferentCase()
+        {
+            string json = "[{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"Department\":\"Department1\",\"JobTitle\":\"JobTitle1\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}," +
+                          "{\"skill\"" +
+                          ":\"Painter\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}]";
+
+
+            var persons = JsonConvert.DeserializeObject<ICollection<Person>>(json);
+            Assert.AreEqual("Painter", (persons.Last() as Artist)?.Skill);
+        }
+
+        [Test]
+        public void FallBackToPArentWhenNotFound()
+        {
+            string json = "[{\"Skl.\":\"Painter\",\"FirstName\":\"FirstName1\",\"LastName\":\"LastName1\"}]";
+
+            var persons = JsonConvert.DeserializeObject<ICollection<Person>>(json);
+            Assert.AreEqual(typeof(Person), persons.First().GetType());
+        }
+
+        [Test]
+        public void ThrowIfManyMatches()
+        {
+            string json = "{\r\n  \"Name\": \"Foo\",\r\n  \"Skill\": \"A\",\r\n  \"JobTitle\": \"B\"\r\n}";
+
+            var jsonSerializationException = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<Person>(json));
+            Assert.AreEqual("Ambiguous type resolution, expected only one type but got: JsonSubTypes.Tests.KnownBaseType_DemoKnownSubTypeWithProperty+Employee, JsonSubTypes.Tests.KnownBaseType_DemoKnownSubTypeWithProperty+Artist", jsonSerializationException.Message);
+        }
+    }
 }

--- a/JsonSubTypes.Tests/DiscriminatorOfDifferentKindTests.cs
+++ b/JsonSubTypes.Tests/DiscriminatorOfDifferentKindTests.cs
@@ -222,4 +222,221 @@ namespace JsonSubTypes.Tests
         }
 
     }
+
+    public class KnownBaseType_DiscriminatorOfDifferentKindTests
+    {
+        [TestFixture]
+        public class DiscriminatorIsAnEnum
+        {
+            public class MainClass
+            {
+                public SubTypeClassBase SubTypeData { get; set; }
+            }
+
+            [JsonConverter(typeof(JsonSubtypes), "SubTypeType")]
+            public class SubTypeClassBase
+            {
+                public SubType SubTypeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), SubType.WithAaaField)]
+            public class SubTypeClass1 : SubTypeClassBase
+            {
+                public string AaaField { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), SubType.WithZzzField)]
+            public class SubTypeClass2 : SubTypeClassBase
+            {
+                public string ZzzField { get; set; }
+            }
+
+            public enum SubType
+            {
+                WithAaaField,
+                WithZzzField
+            }
+
+            [Test]
+            public void Deserialize()
+            {
+                var obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"ZzzField\":\"zzz\",\"SubTypeType\":1}}");
+                Assert.AreEqual("zzz", (obj.SubTypeData as SubTypeClass2)?.ZzzField);
+            }
+        }
+
+        [TestFixture]
+        public class DiscriminatorIsAnEnumStringValue
+        {
+            public class MainClass
+            {
+                public SubTypeClassBase SubTypeData { get; set; }
+            }
+
+            [JsonConverter(typeof(JsonSubtypes), "SubTypeType")]
+            public class SubTypeClassBase
+            {
+                public SubType SubTypeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), SubType.WithAaaField)]
+            public class SubTypeClass1 : SubTypeClassBase
+            {
+                public string AaaField { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), SubType.WithZzzField)]
+            public class SubTypeClass2 : SubTypeClassBase
+            {
+                public string ZzzField { get; set; }
+            }
+
+            [JsonConverter(typeof(StringEnumConverter))]
+            public enum SubType
+            {
+                WithAaaField,
+                [EnumMember(Value = "zzzField")]
+                WithZzzField
+            }
+
+            [Test]
+            public void Deserialize()
+            {
+                var obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"ZzzField\":\"zzz\",\"SubTypeType\":\"zzzField\"}}");
+                Assert.AreEqual("zzz", (obj.SubTypeData as SubTypeClass2)?.ZzzField);
+            }
+        }
+
+        [TestFixture]
+        public class DiscriminatorIsAnInt
+        {
+            class Parent
+            {
+                public Child child { get; set; }
+            }
+
+            [JsonConverter(typeof(JsonSubtypes), "ChildType")]
+            class Child
+            {
+                public virtual int ChildType { get; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Child), 1)]
+            class Child1 : Child
+            {
+                public override int ChildType { get; } = 1;
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Child), 2)]
+            class Child2 : Child
+            {
+                public override int ChildType { get; } = 2;
+            }
+
+            [Test]
+            public void DiscriminatorValueCanBeANumber()
+            {
+                var root1 = JsonConvert.DeserializeObject<Parent>("{\"child\":{\"ChildType\":1}}");
+                var root2 = JsonConvert.DeserializeObject<Parent>("{\"child\":{\"ChildType\":2}}");
+                var root3 = JsonConvert.DeserializeObject<Parent>("{\"child\":{\"ChildType\":8}}");
+                var root4 = JsonConvert.DeserializeObject<Parent>("{\"child\":{\"ChildType\":null}}");
+                var root5 = JsonConvert.DeserializeObject<Parent>("{\"child\":{}}");
+
+                Assert.NotNull(root1.child as Child1);
+                Assert.NotNull(root2.child as Child2);
+                Assert.AreEqual(typeof(Child), root3.child.GetType());
+                Assert.AreEqual(typeof(Child), root4.child.GetType());
+                Assert.AreEqual(typeof(Child), root5.child.GetType());
+            }
+        }
+
+
+        [TestFixture]
+        public class DiscriminatorIsANullableValueType
+        {
+            public class MainClass
+            {
+                public SubTypeClassBase SubTypeData { get; set; }
+            }
+
+            [JsonConverter(typeof(JsonSubtypes), "SubTypeType")]
+            public class SubTypeClassBase
+            {
+                public SubType? SubTypeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), null)]
+            public class SubTypeClass0 : SubTypeClassBase
+            {
+                public string ZeroField { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), SubType.WithAaaField)]
+            public class SubTypeClass1 : SubTypeClassBase
+            {
+                public string AaaField { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), SubType.WithZzzField)]
+            public class SubTypeClass2 : SubTypeClassBase
+            {
+                public string ZzzField { get; set; }
+            }
+
+            public enum SubType
+            {
+                WithAaaField,
+                WithZzzField
+            }
+
+            [Test]
+            public void Deserialize()
+            {
+                var obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"ZzzField\":\"zzz\",\"SubTypeType\":1}}");
+                Assert.AreEqual("zzz", (obj.SubTypeData as SubTypeClass2)?.ZzzField);
+
+                obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"ZeroField\":\"Jack\",\"SubTypeType\": null}}");
+                Assert.AreEqual("Jack", (obj.SubTypeData as SubTypeClass0)?.ZeroField);
+            }
+        }
+
+        [TestFixture]
+        public class DiscriminatorIsANullableRef
+        {
+
+            public class MainClass
+            {
+                public SubTypeClassBase SubTypeData { get; set; }
+            }
+
+            [JsonConverter(typeof(JsonSubtypes), "SubTypeType")]
+            public class SubTypeClassBase
+            {
+                public string SubTypeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), null)]
+            public class NullDiscriminatorClass : SubTypeClassBase
+            {
+                public string CrazyTypeField { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(SubTypeClassBase), "SubTypeClass1")]
+            public class SubTypeClass1 : SubTypeClassBase
+            {
+                public string AaaField { get; set; }
+            }
+
+            [Test]
+            public void Deserialize()
+            {
+                var obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"AaaField\":\"aaa\",\"SubTypeType\": \"SubTypeClass1\"}}");
+                Assert.AreEqual("aaa", (obj.SubTypeData as SubTypeClass1)?.AaaField);
+
+                obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"CrazyTypeField\":\"Jack\",\"SubTypeType\": null}}");
+                Assert.AreEqual("Jack", (obj.SubTypeData as NullDiscriminatorClass)?.CrazyTypeField);
+            }
+        }
+
+    }
 }

--- a/JsonSubTypes.Tests/GenericTests.cs
+++ b/JsonSubTypes.Tests/GenericTests.cs
@@ -3,47 +3,91 @@ using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace JsonSubTypes.Tests
-{[JsonConverter(typeof(JsonSubtypes), "Type")]	
-    [JsonSubtypes.KnownSubType(typeof(Some<>), "Some")]												
-    public interface IResult
-    {
-        string Type { get;}
-    }
-
-    public class SomeInteger: Some<int> {
-        public override string ResultType { get { return "SomeInteger"; }} 
-		
-    }
-
-    public class SomeText: Some<string> {
-        public override string ResultType { get { return "SomeText"; }} 
-		
-    }
-
-    [JsonConverter(typeof(JsonSubtypes), "ResultType")]
-    //[JsonSubtypes.KnownSubType(typeof(SomeInteger), "SomeInteger")]
-    //[JsonSubtypes.KnownSubType(typeof(SomeText), "SomeText")]
-    public abstract class Some<T> : IResult
-    {
-	
-        public string Type { get { return "Some"; }} 
-        public abstract string ResultType { get; }
-        public T Value { get; set; }
-    }
-    
+{
     [TestFixture]
     public class GenericTests
     {
-        
+        [JsonConverter(typeof(JsonSubtypes), "Type")]
+        [JsonSubtypes.KnownSubType(typeof(Some<>), "Some")]
+        public interface IResult
+        {
+            string Type { get; }
+        }
+
+        public class SomeInteger : Some<int>
+        {
+            public override string ResultType { get { return "SomeInteger"; } }
+        }
+
+        public class SomeText : Some<string>
+        {
+            public override string ResultType { get { return "SomeText"; } }
+        }
+
+        [JsonConverter(typeof(JsonSubtypes), "ResultType")]
+        //[JsonSubtypes.KnownSubType(typeof(SomeInteger), "SomeInteger")]
+        //[JsonSubtypes.KnownSubType(typeof(SomeText), "SomeText")]
+        public abstract class Some<T> : IResult
+        {
+            public string Type { get { return "Some"; } }
+            public abstract string ResultType { get; }
+            public T Value { get; set; }
+        }
 
         [Test]
         public void DeserializingSubTypeWithDateParsesCorrectly()
         {
-            var input = new SomeInteger {Value = 42};
+            var input = new SomeInteger { Value = 42 };
             var json = JsonConvert.SerializeObject(input);
 
             Console.WriteLine(json);
-			
+
+            var result = JsonConvert.DeserializeObject<IResult>(json);
+
+            Console.WriteLine(result);
+        }
+    }
+
+    [TestFixture]
+    public class KnownBaseType_GenericTests
+    {
+        [JsonConverter(typeof(JsonSubtypes), "Type")]
+        public interface IResult
+        {
+            string Type { get; }
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(Some<int>), "SomeInteger")]
+        public class SomeInteger : Some<int>
+        {
+            public override string ResultType { get { return "SomeInteger"; } }
+        }
+
+        [JsonSubtypes.KnownBaseType(typeof(Some<string>), "SomeText")]
+        public class SomeText : Some<string>
+        {
+            public override string ResultType { get { return "SomeText"; } }
+        }
+
+        [JsonConverter(typeof(JsonSubtypes), "ResultType")]
+        [JsonSubtypes.KnownBaseType(typeof(IResult), "Some")]
+        //[JsonSubtypes.KnownSubType(typeof(SomeInteger), "SomeInteger")]
+        //[JsonSubtypes.KnownSubType(typeof(SomeText), "SomeText")]
+        public abstract class Some<T> : IResult
+        {
+            public string Type { get { return "Some"; } }
+            public abstract string ResultType { get; }
+            public T Value { get; set; }
+        }
+
+        [Test]
+        public void DeserializingSubTypeWithDateParsesCorrectly()
+        {
+            var input = new SomeInteger { Value = 42 };
+            var json = JsonConvert.SerializeObject(input);
+
+            Console.WriteLine(json);
+
             var result = JsonConvert.DeserializeObject<IResult>(json);
 
             Console.WriteLine(result);

--- a/JsonSubTypes.Tests/HiearachyWithCollectionTests.cs
+++ b/JsonSubTypes.Tests/HiearachyWithCollectionTests.cs
@@ -414,4 +414,408 @@ namespace JsonSubTypes.Tests
             }
         }
     }
+
+    public class KnownBaseType_HiearachyWithCollectionTests
+    {
+        [TestFixture]
+        public class HiearachyWithListsTests
+        {
+            public class Hierachy
+            {
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public Node Root { get; set; }
+            }
+
+            public class Node
+            {
+                public virtual int NodeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 1)]
+            public class FolderNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 1;
+
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public List<Node> Children { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 2)]
+            public class ElemNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 2;
+                public long Size { get; set; }
+            }
+
+            [Test]
+            public void SerializeHierachyTest()
+            {
+                var root = new Hierachy
+                {
+                    Root = new FolderNode
+                    {
+                        Children = new List<Node>
+                        {
+                            new FolderNode
+                            {
+                                Children = new List<Node> {new ElemNode {Size = 3}}
+                            }
+                        }
+                    }
+                };
+
+                var str = JsonConvert.SerializeObject(root);
+
+                Assert.AreEqual(
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}]}}",
+                    str);
+            }
+
+            [Test]
+            public void DeserializeHierachyTest()
+            {
+                var input = "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                var elemNode = ((deserialized?.Root as FolderNode)?.Children.First() as ElemNode)?.Size;
+                Assert.AreEqual(3, elemNode);
+            }
+
+
+
+            [Test]
+            public void DeserializeHierachyDeeperTest()
+            {
+                var input =
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3},{\"NodeType\":2,\"Size\":13}, null]}]}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                Assert.NotNull(deserialized);
+
+                Assert.AreEqual(13,
+                    ((ElemNode)((FolderNode)((FolderNode)((FolderNode)deserialized.Root).Children[0]).Children[0])
+                        .Children[1]).Size);
+            }
+
+            [Test]
+            public void ConcurrentThreadDeserializeHierachyDeeperTest()
+            {
+                Action test = () =>
+                {
+                    var input =
+                        "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3},{\"NodeType\":2,\"Size\":13}, null]}]}]}}";
+
+                    var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                    Assert.NotNull(deserialized);
+
+                    Assert.AreEqual(13,
+                        ((ElemNode)((FolderNode)((FolderNode)((FolderNode)deserialized.Root).Children[0]).Children[0])
+                            .Children[1]).Size);
+                };
+
+                Parallel.For(0, 100, index => test());
+
+            }
+        }
+        [TestFixture]
+        public class HiearachyWithArrayTests
+        {
+            public class Hierachy
+            {
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public Node Root { get; set; }
+            }
+
+            public class Node
+            {
+                public virtual int NodeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 1)]
+            public class FolderNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 1;
+
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public Node[] Children { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 2)]
+            public class ElemNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 2;
+                public long Size { get; set; }
+            }
+
+            [Test]
+            public void SerializeHierachyTest()
+            {
+                var root = new Hierachy
+                {
+                    Root = new FolderNode
+                    {
+                        Children = new[]
+                        {
+                            new FolderNode
+                            {
+                                Children = new[] {new ElemNode {Size = 3}}
+                            }
+                        }
+                    }
+                };
+
+                var str = JsonConvert.SerializeObject(root);
+
+                Assert.AreEqual(
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}]}}",
+                    str);
+            }
+
+            [Test]
+            public void DeserializeHierachyTest()
+            {
+                var input = "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                var elemNode = ((deserialized?.Root as FolderNode)?.Children.First() as ElemNode)?.Size;
+                Assert.AreEqual(3, elemNode);
+            }
+
+            [Test]
+            public void DeserializeBadDocument()
+            {
+                var exception = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Root>("{\"Content\": []}"), "Unrecognized token: Integer");
+
+                Assert.AreEqual("Impossible to read JSON array to fill type: Base", exception.Message);
+            }
+
+
+            [Test]
+            public void DeserializeHierachyDeeperTest()
+            {
+                var input =
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3},{\"NodeType\":2,\"Size\":13}]}]}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                Assert.NotNull(deserialized);
+
+                Assert.AreEqual(13,
+                    ((ElemNode)((FolderNode)((FolderNode)((FolderNode)deserialized.Root).Children[0]).Children[0])
+                        .Children[1]).Size);
+            }
+        }
+
+        [TestFixture]
+        public class HiearachyWithObservableCollectionTests
+        {
+            public class Hierachy
+            {
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public Node Root { get; set; }
+            }
+
+            public class Node
+            {
+                public virtual int NodeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 1)]
+            public class FolderNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 1;
+
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+
+
+#if NET35
+                public List<Node> Children { get; set; }
+#else
+                public ObservableCollection<Node> Children { get; set; }
+#endif
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 2)]
+            public class ElemNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 2;
+                public long Size { get; set; }
+            }
+
+            [Test]
+            public void SerializeHierachyTest()
+            {
+                var root = new Hierachy
+                {
+                    Root = new FolderNode
+                    {
+
+#if NET35
+            Children = new List<Node>
+#else
+                        Children = new ObservableCollection<Node>
+#endif
+
+                        {
+                            new FolderNode
+                            {
+#if NET35
+                                Children = new List<Node> {new ElemNode {Size = 3}}
+#else    
+                                Children = new ObservableCollection<Node> {new ElemNode {Size = 3}}
+#endif
+                                
+                            }
+                        }
+                    }
+                };
+
+                var str = JsonConvert.SerializeObject(root);
+
+                Assert.AreEqual(
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}]}}",
+                    str);
+            }
+
+            [Test]
+            public void DeserializeHierachyTest()
+            {
+                var input = "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                var elemNode = ((deserialized?.Root as FolderNode)?.Children.First() as ElemNode)?.Size;
+                Assert.AreEqual(3, elemNode);
+            }
+
+            [Test]
+            public void DeserializeHierachyDeeperTest()
+            {
+                var input =
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3},{\"NodeType\":2,\"Size\":13}]}]}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                Assert.NotNull(deserialized);
+
+                Assert.AreEqual(13,
+                    ((ElemNode)((FolderNode)((FolderNode)((FolderNode)deserialized.Root).Children[0]).Children[0])
+                        .Children[1]).Size);
+            }
+        }
+        [TestFixture]
+        public class HiearachyWithIEnumerableCollectionTests
+        {
+            public class Hierachy
+            {
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public Node Root { get; set; }
+            }
+
+            public class Node
+            {
+                public virtual int NodeType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 1)]
+            public class FolderNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 1;
+
+                [JsonConverter(typeof(JsonSubtypes), "NodeType")]
+                public IEnumerable<Node> Children { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(Node), 2)]
+            public class ElemNode : Node
+            {
+                public sealed override int NodeType { get; set; } = 2;
+                public long Size { get; set; }
+            }
+
+            [Test]
+            public void SerializeHierachyTest()
+            {
+                var root = new Hierachy
+                {
+                    Root = new FolderNode
+                    {
+#if NET35
+                        Children = new List<Node>
+#else
+                        Children = new ObservableCollection<Node>
+#endif
+                        {
+                            new FolderNode
+                            {
+#if NET35
+                                Children = new List<Node> {new ElemNode {Size = 3}}
+#else    
+                                Children = new ObservableCollection<Node> {new ElemNode {Size = 3}}
+#endif
+
+                            }
+                        }
+                    }
+                };
+
+                var str = JsonConvert.SerializeObject(root);
+
+                Assert.AreEqual(
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}]}}",
+                    str);
+            }
+
+            [Test]
+            public void DeserializeHierachyTest()
+            {
+                var input = "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                var elemNode = ((deserialized?.Root as FolderNode)?.Children.First() as ElemNode)?.Size;
+                Assert.AreEqual(3, elemNode);
+            }
+
+            [Test]
+            public void DeserializeHierachyDeeperTest()
+            {
+                var input =
+                    "{\"Root\":{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":1,\"Children\":[{\"NodeType\":2,\"Size\":3},{\"NodeType\":2,\"Size\":13}]}]}]}}";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                Assert.NotNull(deserialized);
+
+                Assert.AreEqual(13,
+                    ((ElemNode)((FolderNode)((FolderNode)((FolderNode)deserialized.Root).Children.First()).Children
+                        .First()).Children.Skip(1).First()).Size);
+            }
+
+            [Test]
+            public void DeserializeHierachyDeeperTestWithComments()
+            {
+                var input = "/* foo bar */{/* foo bar */\"Root\":" +
+                            "/* foo bar */ /* foo bar */ {/* foo bar */\"NodeType\":1,/* foo bar */\"Children\":" +
+                            "/* foo bar */[/* foo bar */{\"NodeType\":1,/* foo bar */\"Children\":" +
+                            "/* foo bar */[/* foo bar */{\"NodeType\":1,/* foo bar */\"Children\":" +
+                            "/* foo bar */[" +
+                            "/* foo bar */{/* foo bar */\"NodeType\":2,\"Size\":3}/* foo bar */," +
+                            "/* foo bar */{/* foo bar */\"NodeType\":2,\"Size\":13}/* foo bar */]" +
+                            "/* foo bar */}/* foo bar */]/* foo bar */}/* foo bar */]/* foo bar */}/* foo bar */}/* foo bar */";
+
+                var deserialized = JsonConvert.DeserializeObject<Hierachy>(input);
+
+                Assert.NotNull(deserialized);
+
+                Assert.AreEqual(13,
+                    ((ElemNode)((FolderNode)((FolderNode)((FolderNode)deserialized.Root).Children.First()).Children
+                        .First()).Children.Skip(1).First()).Size);
+            }
+        }
+    }
 }

--- a/JsonSubTypes.Tests/JsonPathFallbackTests.cs
+++ b/JsonSubTypes.Tests/JsonPathFallbackTests.cs
@@ -11,7 +11,6 @@ namespace JsonSubTypes.Tests.JsonPath
     [JsonConverter(typeof(JsonSubtypes))]
     [JsonSubtypes.KnownSubTypeWithProperty(typeof(DottedSub), "nested.property")]
     [JsonSubtypes.KnownSubTypeWithProperty(typeof(Nested), "nested.otherproperty")]
-
     class Main
     {
 
@@ -27,7 +26,6 @@ namespace JsonSubTypes.Tests.JsonPath
         [JsonProperty("nested.property")]
         string property { get; set; }
     }
-
 
     class NestedClass
     {
@@ -75,6 +73,116 @@ namespace JsonSubTypes.Tests.JsonPath
     class SubDottedDiscriminator: MainDottedDiscriminator
     {
         
+    }
+
+    [TestFixture]
+    public class JsonPathFallbackTests
+    {
+        [Test]
+        public void CheckDottedProperty()
+        {
+            string json = "{\"nested.property\": \"str\"}";
+            var result = JsonConvert.DeserializeObject<Main>(json);
+            Assert.IsInstanceOf<DottedSub>(result);
+        }
+
+        [Test]
+        public void CheckNestedProperty()
+        {
+            string json = "{nested: { otherproperty: \"abc\" } }";
+            var result = JsonConvert.DeserializeObject<Main>(json);
+            Assert.IsInstanceOf<Nested>(result);
+        }
+
+        [Test]
+        public void CheckNestedDiscriminator()
+        {
+            string json = "{nested: { property: \"SubNestedClass\" } }";
+            var result = JsonConvert.DeserializeObject<MainDiscriminator>(json);
+            Assert.IsInstanceOf<SubDiscriminator>(result);
+        }
+
+        [Test]
+        public void CheckDottedDiscriminator()
+        {
+            string json = "{\"dotted.property\": \"SubNestedClass\"}";
+            var result = JsonConvert.DeserializeObject<MainDottedDiscriminator>(json);
+            Assert.IsInstanceOf<SubDottedDiscriminator>(result);
+        }
+    }
+}
+
+namespace JsonSubTypes.Tests.JsonPath.KnownBaseType
+{
+    [JsonSubtypes.KnownBaseTypeWithProperty(typeof(Main), "nested.otherproperty")]
+    class Nested : Main
+    {
+        string otherproperty { get; set; }
+    }
+
+    [JsonConverter(typeof(JsonSubtypes))]
+    class Main
+    {
+
+    }
+
+    class Sub : Main
+    {
+        Nested nested { get; set; }
+    }
+
+    [JsonSubtypes.KnownBaseTypeWithProperty(typeof(Main), "nested.property")]
+    class DottedSub : Main
+    {
+        [JsonProperty("nested.property")]
+        string property { get; set; }
+    }
+
+    class NestedClass
+    {
+
+    }
+
+    [JsonConverter(typeof(JsonSubtypes), "nested.property")]
+    class MainDiscriminator
+    {
+        public NestedClass nested;
+    }
+
+    class SubNestedClass : NestedClass
+    {
+        string property = "SubNestedClass";
+    }
+
+    class OtherNestedClass : NestedClass
+    {
+        string property = "OtherNestedClass";
+    }
+
+    [JsonSubtypes.KnownBaseType(typeof(MainDiscriminator), "SubNestedClass")]
+    class SubDiscriminator : MainDiscriminator
+    {
+        new SubNestedClass nested { get; set; }
+    }
+
+    [JsonSubtypes.KnownBaseType(typeof(MainDiscriminator), "OtherNestedClass")]
+    class OtherDiscriminator : MainDiscriminator
+    {
+        new OtherNestedClass nested { get; set; }
+    }
+
+
+    [JsonConverter(typeof(JsonSubtypes), "dotted.property")]
+    class MainDottedDiscriminator
+    {
+        [JsonProperty("dotted.property")]
+        string property { get; set; }
+    }
+
+    [JsonSubtypes.KnownBaseType(typeof(MainDottedDiscriminator), "SubNestedClass")]
+    class SubDottedDiscriminator : MainDottedDiscriminator
+    {
+
     }
 
     [TestFixture]

--- a/JsonSubTypes.Tests/JsonSubTypesTests.cs
+++ b/JsonSubTypes.Tests/JsonSubTypesTests.cs
@@ -255,3 +255,255 @@ namespace JsonSubTypes.Tests
         }
     }
 }
+
+namespace JsonSubTypes.Tests.KnownBaseType
+{
+    class Root
+    {
+        public Base Content { get; set; }
+        public List<Base> ContentList { get; set; }
+
+        protected bool Equals(Root other)
+        {
+            if (Equals(Content, other.Content))
+            {
+                return ContentList == null || other.ContentList == null
+                    ? ReferenceEquals(ContentList, other.ContentList)
+                    : ContentList.SequenceEqual(other.ContentList);
+            }
+            return false;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((Root)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Content != null ? Content.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (ContentList != null
+                               ? ContentList.Aggregate(0, (x, y) => x.GetHashCode() ^ y.GetHashCode())
+                               : 0);
+                return hashCode;
+            }
+        }
+    }
+
+    [JsonConverter(typeof(JsonSubtypes), "@type")]
+    class Base
+    {
+        [JsonProperty("@type")]
+        public virtual string Type { get; }
+
+        [JsonProperty("4-you")]
+        public int _4You { get; set; }
+
+        protected bool Equals(Base other)
+        {
+            return string.Equals(Type, other.Type) && _4You == other._4You;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is Base && Equals((Base)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Type != null ? Type.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ _4You;
+                return hashCode;
+            }
+        }
+    }
+
+    [JsonSubtypes.KnownBaseType(typeof(Base), "SubB")]
+    class SubB : Base
+    {
+        public override string Type { get; } = "SubB";
+        public int Index { get; set; }
+
+        protected bool Equals(SubB other)
+        {
+            return base.Equals(other) && Index == other.Index;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is SubB && Equals((SubB)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (base.GetHashCode() * 397) ^ Index;
+            }
+        }
+    }
+
+    [JsonSubtypes.KnownBaseType(typeof(Base), "SubC")]
+    class SubC : Base
+    {
+        public override string Type { get; } = "SubC";
+
+        public string Name { get; set; }
+
+        protected bool Equals(SubC other)
+        {
+            return base.Equals(other) && string.Equals(Name, other.Name);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is SubC && Equals((SubC)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (base.GetHashCode() * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+            }
+        }
+    }
+    [TestFixture]
+    public class JsonSubTypesTests
+    {
+        [Test]
+        public void SerializeTest()
+        {
+            var root = new Root
+            {
+                Content = new SubB
+                {
+                    Index = 1,
+                    _4You = 2
+                }
+            };
+
+            string str = JsonConvert.SerializeObject(root);
+
+            Assert.AreEqual("{\"Content\":{\"@type\":\"SubB\",\"Index\":1,\"4-you\":2},\"ContentList\":null}", str);
+        }
+
+        [Test]
+        public void DeserializeSubType()
+        {
+            var expected = new Root
+            {
+                Content = new SubB { Index = 1 }
+            };
+
+            var root = JsonConvert.DeserializeObject<Root>("{\"Content\":{\"Index\":1,\"@type\":\"SubB\"}}");
+
+            Assert.AreEqual(expected, root);
+        }
+
+        [Test]
+        public void DeserializeSubTypeWithComments()
+        {
+            var expected = new Root
+            {
+                Content = new SubB { Index = 1 }
+            };
+
+            var root = JsonConvert.DeserializeObject<Root>(
+                "{\"Content\":/* foo bar */{\"Index\":1,\"@type\":\"SubB\"}}");
+
+            Assert.AreEqual(expected, root);
+        }
+
+        [Test]
+        public void DeserializeNull()
+        {
+            var expected = new Root
+            {
+                Content = null
+            };
+
+            var root = JsonConvert.DeserializeObject<Root>("{\"Content\":null}");
+
+            Assert.AreEqual(expected, root);
+        }
+
+        [Test]
+        public void DeserializeBadDocument()
+        {
+            var exception = Assert.Throws<JsonReaderException>(() => JsonConvert.DeserializeObject<Root>("{\"Content\":8}"));
+
+            Assert.AreEqual("Unrecognized token: Integer", exception.Message);
+        }
+
+        [Test]
+        public void WhenDiscriminatorValueIsNullDeserializeToBaseType()
+        {
+            var expected = new Root
+            {
+                Content = new Base()
+            };
+
+            var root = JsonConvert.DeserializeObject<Root>("{\"Content\":{\"Index\":1,\"@type\":null}}");
+
+            Assert.AreEqual(expected, root);
+        }
+
+        [Test]
+        public void WhenDiscriminatorValueIsUnknownDeserializeToBaseType()
+        {
+            var expected = new Root
+            {
+                Content = new Base()
+            };
+
+            var root = JsonConvert.DeserializeObject<Root>("{\"Content\":{\"Index\":1,\"@type\":8.5}}");
+
+            Assert.AreEqual(expected, root);
+        }
+
+        [Test]
+        public void WorkWithSubList()
+        {
+            var expected = new Root
+            {
+                Content = new Base(),
+                ContentList = new List<Base> { new SubB { Index = 1 }, new SubC { Name = "foo" } }
+            };
+
+            var root = JsonConvert.DeserializeObject<Root>(
+                "{\"Content\":{\"Index\":1,\"@type\":8.5},\"ContentList\":[{\"Index\":1,\"@type\":\"SubB\"},{\"Name\":\"foo\",\"@type\":\"SubC\"}]}");
+
+            Assert.AreEqual(expected, root);
+        }
+
+        [Test]
+        public void CouldNotBeUsedAsRegisteredConverter()
+        {
+            var converter = new JsonSubtypes();
+            Assert.False(converter.CanConvert(typeof(SubB)));
+            Assert.False(converter.CanConvert(typeof(Base)));
+        }
+
+        [Test]
+        public void RefuseToWrite()
+        {
+            var converter = new JsonSubtypes();
+            Assert.False(converter.CanWrite);
+            Assert.Throws<NotImplementedException>(() => converter.WriteJson(null, null, null));
+        }
+    }
+}

--- a/JsonSubTypes.Tests/TypePropertyCase.cs
+++ b/JsonSubTypes.Tests/TypePropertyCase.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace JsonSubTypes.Tests
 {
-
     public class TypePropertyCase
     {
         public class TypePropertyCase_LowerWithHigher
@@ -110,6 +109,133 @@ namespace JsonSubTypes.Tests
                 public virtual int MsgType { get; set; }
             }
 
+            class Foo : DtoBase
+            {
+            }
+
+            [Test]
+            public void FooParsingCamelCase()
+            {
+                var serializeObject = "{\"MessageType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+
+            [Test]
+            public void FooParsingLowerPascalCase()
+            {
+                var serializeObject = "{\"messageType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+        }
+    }
+
+    public class KnownBaseType_TypePropertyCase
+    {
+        public class TypePropertyCase_LowerWithHigher
+        {
+            [JsonConverter(typeof(JsonSubtypes), "msgType")]
+            public abstract class DtoBase
+            {
+                public virtual int MsgType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(DtoBase), 1)]
+            class Foo : DtoBase
+            {
+            }
+
+            [Test]
+            public void FooParsingCamelCase()
+            {
+                var serializeObject = "{\"MsgType\":1}";
+                var msgType = JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType;
+                Assert.AreEqual(1, msgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+
+            [Test]
+            public void FooParsingLowerPascalCase()
+            {
+                var serializeObject = "{\"msgType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+        }
+
+        public class TypePropertyCase_HigherWithLower
+        {
+            [JsonConverter(typeof(JsonSubtypes), "MsgType")]
+            public abstract class DtoBase
+            {
+                [JsonProperty("msgType")]
+                public virtual int MsgType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(DtoBase), 1)]
+            class Foo : DtoBase
+            {
+            }
+
+            [Test]
+            public void FooParsingCamelCase()
+            {
+                var serializeObject = "{\"MsgType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+
+            [Test]
+            public void FooParsingLowerPascalCase()
+            {
+                var serializeObject = "{\"msgType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+        }
+
+        public class TypePropertyCase_RedirectLowerWithHigher
+        {
+            [JsonConverter(typeof(JsonSubtypes), "messageType")]
+            public abstract class DtoBase
+            {
+                [JsonProperty("MessageType")]
+                public virtual int MsgType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(DtoBase), 1)]
+            class Foo : DtoBase
+            {
+            }
+
+            [Test]
+            public void FooParsingCamelCase()
+            {
+                var serializeObject = "{\"MessageType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+
+            [Test]
+            public void FooParsingLowerPascalCase()
+            {
+                var serializeObject = "{\"messageType\":1}";
+                Assert.AreEqual(1, JsonConvert.DeserializeObject<Foo>(serializeObject).MsgType);
+                Assert.IsInstanceOf<Foo>(JsonConvert.DeserializeObject<DtoBase>(serializeObject));
+            }
+        }
+
+        public class TypePropertyCase_RedirectHigherWithLower
+        {
+            [JsonConverter(typeof(JsonSubtypes), "MessageType")]
+            public abstract class DtoBase
+            {
+                [JsonProperty("messageType")]
+                public virtual int MsgType { get; set; }
+            }
+
+            [JsonSubtypes.KnownBaseType(typeof(DtoBase), 1)]
             class Foo : DtoBase
             {
             }

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -53,6 +53,19 @@ namespace JsonSubTypes
             }
         }
 
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
+        public class KnownBaseTypeAttribute : Attribute
+        {
+            public Type BaseType { get; }
+            public object AssociatedValue { get; }
+
+            public KnownBaseTypeAttribute(Type baseType, object associatedValue)
+            {
+                BaseType = baseType;
+                AssociatedValue = associatedValue;
+            }
+        }
+
         [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
         public class FallBackSubTypeAttribute : Attribute
         {
@@ -78,6 +91,20 @@ namespace JsonSubTypes
             }
         }
 
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
+        public class KnownBaseTypeWithPropertyAttribute : Attribute
+        {
+            public Type BaseType { get; }
+            public string PropertyName { get; }
+            public bool StopLookupOnMatch { get; set; }
+
+            public KnownBaseTypeWithPropertyAttribute(Type baseType, string propertyName)
+            {
+                BaseType = baseType;
+                PropertyName = propertyName;
+            }
+        }
+
         protected readonly string JsonDiscriminatorPropertyName;
 
         [ThreadStatic] private static bool _isInsideRead;
@@ -86,9 +113,11 @@ namespace JsonSubTypes
 
 #if NET35
         private static readonly Dictionary<TypeInfo, IEnumerable<object>> _attributesCache = new Dictionary<TypeInfo, IEnumerable<object>>();
+        private static readonly Dictionary<TypeInfo, IEnumerable<Type>> _typesWithKnownBaseTypeAttributesCache = new Dictionary<TypeInfo, IEnumerable<Type>>();
 #else
         private static readonly ConcurrentDictionary<TypeInfo, IEnumerable<object>> _attributesCache = new ConcurrentDictionary<TypeInfo, IEnumerable<object>>();
         private static readonly Func<TypeInfo, IEnumerable<object>> _getCustomAttributes = ti => ti.GetCustomAttributes(false);
+        private static readonly ConcurrentDictionary<TypeInfo, IEnumerable<Type>> _typesWithKnownBaseTypeAttributesCache = new ConcurrentDictionary<TypeInfo, IEnumerable<Type>>();
 #endif
 
         public override bool CanRead
@@ -144,16 +173,16 @@ namespace JsonSubTypes
                     value = ReadObject(reader, objectType, serializer);
                     break;
                 case JsonToken.StartArray:
-                {
-                    var elementType = GetElementType(objectType);
-                    if (elementType == null)
                     {
-                        throw CreateJsonReaderException(reader, $"Impossible to read JSON array to fill type: {objectType.Name}");
-                    }
+                        var elementType = GetElementType(objectType);
+                        if (elementType == null)
+                        {
+                            throw CreateJsonReaderException(reader, $"Impossible to read JSON array to fill type: {objectType.Name}");
+                        }
 
-                    value = ReadArray(reader, objectType, elementType, serializer);
-                    break;
-                }
+                        value = ReadArray(reader, objectType, elementType, serializer);
+                        break;
+                    }
                 default:
                     throw CreateJsonReaderException(reader, $"Unrecognized token: {reader.TokenType}");
             }
@@ -342,6 +371,17 @@ namespace JsonSubTypes
         {
             return GetAttributes<KnownSubTypeWithPropertyAttribute>(ToTypeInfo(parentType))
                 .Select(a => new TypeWithPropertyMatchingAttributes(a.SubType, a.PropertyName, a.StopLookupOnMatch))
+                .Concat(
+                    FindTypesWithAttribute(ToTypeInfo(typeof(KnownBaseTypeWithPropertyAttribute)))
+                    .Where(x => GetAttributes<KnownBaseTypeWithPropertyAttribute>(ToTypeInfo(x)).Any(t => t.BaseType == parentType))
+                    .Select(x =>
+                    {
+                        var firstAttribute = GetAttributes<KnownBaseTypeWithPropertyAttribute>(ToTypeInfo(x))
+                                                        .Where(t => t.BaseType == parentType)
+                                                        .First();
+                        return new TypeWithPropertyMatchingAttributes(x, firstAttribute.PropertyName, firstAttribute.StopLookupOnMatch);
+                    })
+                )
                 .ToList();
         }
 
@@ -463,6 +503,19 @@ namespace JsonSubTypes
                 .ToList()
                 .ForEach(x => dictionary.Add(x.AssociatedValue, x.SubType));
 
+            FindTypesWithAttribute(ToTypeInfo(typeof(KnownBaseTypeAttribute)))
+                .Where(x => GetAttributes<KnownBaseTypeAttribute>(ToTypeInfo(x)).Any(t => t.BaseType == type))
+                .Select(x => new
+                {
+                    AssociatedValue = GetAttributes<KnownBaseTypeAttribute>(ToTypeInfo(x))
+                                                .Where(t => t.BaseType == type)
+                                                .Select(t => t.AssociatedValue)
+                                                .First(),
+                    SubType = x
+                })
+                .ToList()
+                .ForEach(x => dictionary.Add(x.AssociatedValue, x.SubType));
+
             return dictionary;
         }
 
@@ -512,6 +565,47 @@ namespace JsonSubTypes
         private static T GetAttribute<T>(TypeInfo typeInfo) where T : Attribute
         {
             return GetAttributes<T>(typeInfo).FirstOrDefault();
+        }
+
+        private static IEnumerable<Type> FindTypesWithAttribute(TypeInfo attributeType)
+        {
+            IEnumerable<Type> _getTypesWithCustomAttribute()
+            {
+#if NETSTANDARD1_3
+                return new Type[0];
+#else
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+                foreach (var assembly in assemblies)
+                {
+                    // Get types from the assembly
+                    var types = assembly.GetTypes();
+
+                    // Filter types based on the presence of the attribute and its property value
+                    var filteredTypes = types
+                            .Where(t => t.GetCustomAttributes(attributeType, false).Any());
+
+                    foreach (var t in filteredTypes)
+                    {
+                        yield return t;
+                    }
+                }
+#endif
+            };
+
+#if NET35
+            lock (_attributesCache)
+            {
+                if (_typesWithKnownBaseTypeAttributesCache.TryGetValue(attributeType, out var res))
+                    return res;
+
+                    res = _getTypesWithCustomAttribute();
+                _typesWithKnownBaseTypeAttributesCache.Add(attributeType, res);
+
+                return res;
+            }
+#else
+            return _typesWithKnownBaseTypeAttributesCache.GetOrAdd(attributeType, _getTypesWithCustomAttribute());
+#endif
         }
 
         private static IEnumerable<Type> GetGenericTypeArguments(Type type)


### PR DESCRIPTION
Added `KnownBaseTypeAttribute` and `KnownBaseTypeWithPropertyAttribute` attributes, which are basically the inversion of `KnownSubTypeAttribute` and `KnownSubTypeWithPropertyAttribute.`

Basically, the problem we were facing is we've got base classes which reside in nuget packages/other projects.
Currently, you needed to 1) have access to those base classes to add all needed attributes and thus 2) your derived classes needed to exist in the same project as their base class.

With these changes, we can mark our base class as `[JsonConverter(typeof(JsonSubtypes), "SomePropertyName")]`.
Then, any other project can create derived classes and mark them via `[JsonSubtypes.KnownBaseTypeWithProperty(typeof(SomeBaseClass), "SomePropertyValue")]`.

It uses the same caching method as the GetAttributes function, so the added performance overhead would be minimal. 
You'd only need to scan all assemblies once to find those attributes.