### PR TITLE
Fix incorrect paths in errors and exceptions during subtype deserialization (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### JsonSubTypes
 #### Fixed
 - Deserialization with an open generic base type (e.g. `Base<>`) now closes the generic subtype correctly (e.g. `Nested1<int>` for `Base<int>`) instead of failing. #177
+- Errors and exceptions raised while deserializing a subtype now carry the fully qualified JSON path (e.g. `Property2.Value` instead of `Value`), matching stock Newtonsoft.Json error handling. #182
 
 ## [1.0.0-rc.2] - 2026-08-10
 ### Changed

--- a/JsonSubTypes.Tests/ErrorPathTests.cs
+++ b/JsonSubTypes.Tests/ErrorPathTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+    [TestFixture]
+    public class ErrorPathTests
+    {
+        public class RootObject
+        {
+            public BaseClass Property2 { get; set; }
+            public SubClassB Property3 { get; set; }
+        }
+
+        public abstract class BaseClass
+        {
+        }
+
+        public class SubClassA : BaseClass
+        {
+            public float Value { get; set; }
+        }
+
+        public class SubClassB : BaseClass
+        {
+            public int Value { get; set; }
+        }
+
+        private static JsonSerializerSettings CreateSettings(Action<Newtonsoft.Json.Serialization.ErrorEventArgs> onError)
+        {
+            return new JsonSerializerSettings
+            {
+                Converters =
+                {
+                    JsonSubtypesConverterBuilder
+                        .Of<BaseClass>("$kind")
+                        .RegisterSubtype<SubClassA>("a")
+                        .RegisterSubtype<SubClassB>("b")
+                        .Build()
+                },
+                Error = (sender, args) => onError(args)
+            };
+        }
+
+        [Test]
+        public void DeserializationErrorWithinSubtypeReportsFullyQualifiedPath()
+        {
+            var paths = new List<string>();
+            var settings = CreateSettings(args =>
+            {
+                if (args.CurrentObject == args.ErrorContext.OriginalObject)
+                {
+                    paths.Add(args.ErrorContext.Path);
+                }
+            });
+
+            JsonReaderException thrown = null;
+            try
+            {
+                using (var jsonReader = new JsonTextReader(new System.IO.StringReader(
+                    "{\"Property2\":{\"$kind\":\"a\",\"Value\":\"not a float\"}}")))
+                {
+                    JsonSerializer.CreateDefault(settings).Deserialize<RootObject>(jsonReader);
+                }
+            }
+            catch (JsonReaderException ex)
+            {
+                thrown = ex;
+            }
+
+            CollectionAssert.Contains(paths, "Property2.Value");
+            Assert.That(thrown, Is.Not.Null);
+            Assert.AreEqual("Property2.Value", thrown.Path);
+        }
+
+        [Test]
+        public void DeserializationErrorWithinDirectlyTypedSubtypeReportsFullyQualifiedPath()
+        {
+            var paths = new List<string>();
+            var settings = CreateSettings(args =>
+            {
+                if (args.CurrentObject == args.ErrorContext.OriginalObject)
+                {
+                    paths.Add(args.ErrorContext.Path);
+                }
+            });
+
+            JsonReaderException thrown = null;
+            try
+            {
+                using (var jsonReader = new JsonTextReader(new System.IO.StringReader(
+                    "{\"Property3\":{\"Value\":\"not an int\"}}")))
+                {
+                    JsonSerializer.CreateDefault(settings).Deserialize<RootObject>(jsonReader);
+                }
+            }
+            catch (JsonReaderException ex)
+            {
+                thrown = ex;
+            }
+
+            CollectionAssert.Contains(paths, "Property3.Value");
+            Assert.That(thrown, Is.Not.Null);
+            Assert.AreEqual("Property3.Value", thrown.Path);
+        }
+
+        [Test]
+        public void DeserializationWithoutErrorsRaisesNoErrorEvent()
+        {
+            var errors = new List<string>();
+            var settings = CreateSettings(args => errors.Add(args.ErrorContext.Path));
+
+            using (var jsonReader = new JsonTextReader(new System.IO.StringReader(
+                "{\"Property2\":{\"$kind\":\"a\",\"Value\":3.14},\"Property3\":{\"Value\":42}}")))
+            {
+                var root = JsonSerializer.CreateDefault(settings).Deserialize<RootObject>(jsonReader);
+
+                Assert.That(root.Property2, Is.InstanceOf<SubClassA>());
+                Assert.That(root.Property3, Is.InstanceOf<SubClassB>());
+                Assert.That(((SubClassA)root.Property2).Value, Is.EqualTo(3.14f));
+            }
+
+            CollectionAssert.IsEmpty(errors);
+        }
+
+        public class NestedRootObject
+        {
+            public BaseClass Property2 { get; set; }
+        }
+
+        public class NestedSubClassA : BaseClass
+        {
+            public BaseClass Nested { get; set; }
+        }
+
+        public class NestedSubClassB : BaseClass
+        {
+            public int Value { get; set; }
+        }
+
+        [Test]
+        public void DeserializationErrorWithinNestedSubtypeReportsFullyQualifiedPath()
+        {
+            var paths = new List<string>();
+            var settings = new JsonSerializerSettings
+            {
+                Converters =
+                {
+                    JsonSubtypesConverterBuilder
+                        .Of<BaseClass>("$kind")
+                        .RegisterSubtype<NestedSubClassA>("a")
+                        .RegisterSubtype<NestedSubClassB>("b")
+                        .Build()
+                },
+                Error = (sender, args) =>
+                {
+                    if (args.CurrentObject == args.ErrorContext.OriginalObject)
+                    {
+                        paths.Add(args.ErrorContext.Path);
+                    }
+                }
+            };
+
+            JsonReaderException thrown = null;
+            try
+            {
+                using (var jsonReader = new JsonTextReader(new System.IO.StringReader(
+                    "{\"Property2\":{\"$kind\":\"a\",\"Nested\":{\"$kind\":\"b\",\"Value\":\"not an int\"}}}")))
+                {
+                    JsonSerializer.CreateDefault(settings).Deserialize<NestedRootObject>(jsonReader);
+                }
+            }
+            catch (JsonReaderException ex)
+            {
+                thrown = ex;
+            }
+
+            CollectionAssert.Contains(paths, "Property2.Nested.Value");
+            Assert.That(thrown, Is.Not.Null);
+            Assert.AreEqual("Property2.Nested.Value", thrown.Path);
+        }
+    }
+}

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -98,7 +98,7 @@ namespace JsonSubTypes
                 if (!_isInsideRead)
                     return true;
 
-                return !string.IsNullOrEmpty(_reader.Path);
+                return _reader.Depth != 0;
             }
         }
 
@@ -226,7 +226,7 @@ namespace JsonSubTypes
 
         private static JsonReader CreateAnotherReader(JToken jToken, JsonReader reader)
         {
-            var jObjectReader = jToken.CreateReader();
+            var jObjectReader = new JTokenReader(jToken, reader.Path);
             jObjectReader.Culture = reader.Culture;
             jObjectReader.CloseInput = reader.CloseInput;
             jObjectReader.SupportMultipleContent = reader.SupportMultipleContent;


### PR DESCRIPTION
Closes #182

## Problem

Errors and exceptions raised while deserializing a subtype reported the wrong JSON path. When `JsonSerializerSettings.Error` was used, an error inside a resolved subtype surfaced as `Value` instead of `Property2.Value`, and the exception thrown by `Deserialize` carried the truncated path too.

Root cause: `JsonSubtypes` replays the resolved subtype through a fresh `JTokenReader` created with `jToken.CreateReader()`, which starts with an empty path. Errors raised inside that reader are therefore relative to the subtype object.

The reporter correctly identified the blocker: seeding the reader's path (`new JTokenReader(jToken, reader.Path)`) breaks the recursion guard in `CanRead`, which detected the internal reader's start by its *empty* path and would otherwise loop forever.

## Fix

Two small changes in `JsonSubtypes.cs`:

- `CreateAnotherReader` seeds the internal reader with the current reader path (`new JTokenReader(jToken, reader.Path)`), so error paths are fully qualified.
- `CanRead` detects the internal reader's start with `_reader.Depth != 0` instead of the path string. For a `JTokenReader` rooted at an object, depth is `0` exactly at the fresh/root position (which must decline to avoid recursion) and `>= 1` everywhere a nested subtype legitimately needs the converter.

Verified equivalent to the previous guard on the reachable states; the full test suite (147 tests, including deep nesting, hierarchies, arrays and 100-iteration concurrency) passes unchanged apart from the added tests.

## Tests

New `ErrorPathTests` covers:
- error in a subtype resolved via discriminator → path `Property2.Value`
- error in a directly-typed subtype → path `Property3.Value`
- error in a nested subtype → path `Property2.Nested.Value`
- no error → no `Error` event

Coverage of the modified code (coverlet): 100% lines, `get_CanRead` 100% lines + 100% branches.

## Honest note about a residual behaviour

When the `Error` handler does **not** set `ErrorContext.Handled = true`, the error is reported twice: once at the fully qualified path (e.g. `Property2.Value`, now correct) and once by the outer Newtonsoft reader at the containing property (e.g. `Property2`). This is structural: the exception crosses two Newtonsoft error-handling layers because the subtype is replayed through a second reader. I verified a plain two-layer converter reproduces the same duplicate event. A single event at the full path is not achievable without redesigning the converter. With `Handled = true` the behaviour is clean: a single event at the correct path and no exception.
