### PR TITLE
Add OnUnresolvedSubtype callback to detect unregistered subtypes (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### JsonSubTypes
+#### Added
+- `OnUnresolvedSubtype` on `JsonSubtypesConverterBuilder` and `JsonSubtypesWithPropertyConverterBuilder`: a callback invoked once per JSON element whose subtype cannot be resolved (unknown or missing discriminator value, or no matching property). #112
 #### Fixed
 - Deserialization with an open generic base type (e.g. `Base<>`) now closes the generic subtype correctly (e.g. `Nested1<int>` for `Base<int>`) instead of failing. #177
 - Errors and exceptions raised while deserializing a subtype now carry the fully qualified JSON path (e.g. `Property2.Value` instead of `Value`), matching stock Newtonsoft.Json error handling. #182
+
+### JsonSubTypes.Text.Json
+#### Added
+- `OnUnresolvedSubtype` on `JsonSubtypesConverterBuilder` and `JsonSubtypesWithPropertyConverterBuilder`: the `System.Text.Json` equivalent of the Newtonsoft.Json callback above. #112
 
 ## [1.0.0-rc.2] - 2026-08-10
 ### Changed

--- a/JsonSubTypes.Tests/UnresolvedSubtypeCallbackTests.cs
+++ b/JsonSubTypes.Tests/UnresolvedSubtypeCallbackTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+    [TestFixture]
+    public class UnresolvedSubtypeCallbackTests
+    {
+        public abstract class Animal
+        {
+            public int Age { get; set; }
+        }
+
+        public class Dog : Animal
+        {
+            public bool CanBark { get; set; }
+        }
+
+        public class Cat : Animal
+        {
+            public int Lives { get; set; }
+        }
+
+        public class UnknownAnimal : Animal
+        {
+        }
+
+        public interface IStep
+        {
+            string Type { get; set; }
+            IList<IStep> Steps { get; set; }
+        }
+
+        public class RegisteredStep : IStep
+        {
+            public string Type { get; set; }
+            public IList<IStep> Steps { get; set; }
+        }
+
+        public class UnknownStepsTrap : IStep
+        {
+            public string Type { get; set; }
+            public IList<IStep> Steps { get; set; }
+        }
+
+        private static JsonSerializerSettings DiscriminatorSettings(IList<UnresolvedSubtypeInfo> notifications,
+            bool withFallback)
+        {
+            var builder = JsonSubtypesConverterBuilder
+                .Of(typeof(Animal), "type")
+                .RegisterSubtype(typeof(Cat), "Cat")
+                .RegisterSubtype(typeof(Dog), "Dog")
+                .OnUnresolvedSubtype(notifications.Add);
+            if (withFallback)
+            {
+                builder.SetFallbackSubtype(typeof(UnknownAnimal));
+            }
+
+            return new JsonSerializerSettings
+            {
+                Converters = { builder.Build() }
+            };
+        }
+
+        [Test]
+        public void CallbackNotInvokedWhenSubtypeIsResolved()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var settings = DiscriminatorSettings(notifications, true);
+
+            var result = JsonConvert.DeserializeObject<Animal>("{\"type\":\"Cat\",\"age\":3,\"lives\":7}", settings);
+
+            Assert.IsInstanceOf<Cat>(result);
+            Assert.AreEqual(0, notifications.Count);
+        }
+
+        [Test]
+        public void CallbackInvokedForUnknownDiscriminatorValue()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var settings = DiscriminatorSettings(notifications, true);
+
+            var result = JsonConvert.DeserializeObject<Animal>("{\"type\":\"NonExistentType42\",\"age\":3}", settings);
+
+            Assert.IsInstanceOf<UnknownAnimal>(result);
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(typeof(Animal), notifications[0].ParentType);
+            Assert.AreEqual("type", notifications[0].DiscriminatorPropertyName);
+            Assert.AreEqual("NonExistentType42", notifications[0].DiscriminatorValue);
+            Assert.IsTrue(notifications[0].HasDiscriminator);
+            Assert.AreEqual(typeof(UnknownAnimal), notifications[0].FallbackSubtype);
+        }
+
+        [Test]
+        public void CallbackInvokedForMissingDiscriminator()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var settings = DiscriminatorSettings(notifications, true);
+
+            var result = JsonConvert.DeserializeObject<Animal>("{\"age\":3}", settings);
+
+            Assert.IsInstanceOf<UnknownAnimal>(result);
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(typeof(Animal), notifications[0].ParentType);
+            Assert.IsNull(notifications[0].DiscriminatorValue);
+            Assert.IsFalse(notifications[0].HasDiscriminator);
+        }
+
+        [Test]
+        public void CallbackInvokedEvenWithoutFallbackSubtype()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var settings = DiscriminatorSettings(notifications, false);
+
+            Assert.Throws<JsonSerializationException>(() =>
+                JsonConvert.DeserializeObject<Animal>("{\"type\":\"NonExistentType42\"}", settings));
+
+            Assert.AreEqual(1, notifications.Count);
+            Assert.IsNull(notifications[0].FallbackSubtype);
+            Assert.AreEqual("NonExistentType42", notifications[0].DiscriminatorValue);
+        }
+
+        [Test]
+        public void CallbackInvokedForEachUnresolvedElementInTree()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var settings = new JsonSerializerSettings
+            {
+                Converters =
+                {
+                    JsonSubtypesConverterBuilder
+                        .Of(typeof(IStep), "Type")
+                        .SetFallbackSubtype(typeof(UnknownStepsTrap))
+                        .RegisterSubtype(typeof(RegisteredStep), "RegisteredStep")
+                        .OnUnresolvedSubtype(notifications.Add)
+                        .Build()
+                }
+            };
+
+            var json = "[" +
+                       "{\"Type\":\"NonExistentType42\"}," +
+                       "{\"Type\":\"RegisteredStep\"}," +
+                       "{\"Type\":\"AnotherUnknownType\",\"Steps\":[{\"Type\":\"AlsoUnknown\"}]}" +
+                       "]";
+
+            var result = JsonConvert.DeserializeObject<List<IStep>>(json, settings);
+
+            Assert.IsInstanceOf<UnknownStepsTrap>(result[0]);
+            Assert.IsInstanceOf<RegisteredStep>(result[1]);
+            Assert.IsInstanceOf<UnknownStepsTrap>(result[2]);
+            Assert.IsInstanceOf<UnknownStepsTrap>(result[2].Steps[0]);
+            Assert.AreEqual(3, notifications.Count);
+            Assert.AreEqual(new[] { "NonExistentType42", "AnotherUnknownType", "AlsoUnknown" },
+                notifications.ConvertAll(n => n.DiscriminatorValue));
+        }
+
+        [Test]
+        public void CallbackInvokedInPropertyPresenceMode()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var settings = new JsonSerializerSettings
+            {
+                Converters =
+                {
+                    JsonSubtypesWithPropertyConverterBuilder
+                        .Of(typeof(Animal))
+                        .RegisterSubtypeWithProperty(typeof(Cat), "catLives")
+                        .RegisterSubtypeWithProperty(typeof(Dog), "canBark")
+                        .SetFallbackSubtype(typeof(UnknownAnimal))
+                        .OnUnresolvedSubtype(notifications.Add)
+                        .Build()
+                }
+            };
+
+            var result = JsonConvert.DeserializeObject<Animal>("{\"age\":3}", settings);
+
+            Assert.IsInstanceOf<UnknownAnimal>(result);
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(typeof(Animal), notifications[0].ParentType);
+            Assert.IsNull(notifications[0].DiscriminatorPropertyName);
+            Assert.IsFalse(notifications[0].HasDiscriminator);
+            Assert.AreEqual(typeof(UnknownAnimal), notifications[0].FallbackSubtype);
+        }
+    }
+}

--- a/JsonSubTypes.Text.Json.Tests/UnresolvedSubtypeCallbackTests.cs
+++ b/JsonSubTypes.Text.Json.Tests/UnresolvedSubtypeCallbackTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JsonSubTypes.Text.Json;
+using NUnit.Framework;
+
+namespace JsonSubTypes.Tests
+{
+    [TestFixture]
+    public class UnresolvedSubtypeCallbackTests
+    {
+        public abstract class Animal
+        {
+            [JsonPropertyName("age")]
+            public int Age { get; set; }
+        }
+
+        public class Dog : Animal
+        {
+            public bool CanBark { get; set; }
+        }
+
+        public class Cat : Animal
+        {
+            public int Lives { get; set; }
+        }
+
+        public class UnknownAnimal : Animal
+        {
+        }
+
+        public interface IStep
+        {
+            [JsonPropertyName("Type")]
+            string Type { get; set; }
+
+            List<IStep> Steps { get; set; }
+        }
+
+        public class RegisteredStep : IStep
+        {
+            [JsonPropertyName("Type")]
+            public string Type { get; set; }
+
+            public List<IStep> Steps { get; set; }
+        }
+
+        public class UnknownStepsTrap : IStep
+        {
+            [JsonPropertyName("Type")]
+            public string Type { get; set; }
+
+            public List<IStep> Steps { get; set; }
+        }
+
+        private static JsonSerializerOptions DiscriminatorOptions(IList<UnresolvedSubtypeInfo> notifications,
+            bool withFallback)
+        {
+            var builder = JsonSubtypesConverterBuilder
+                .Of(typeof(Animal), "type")
+                .RegisterSubtype(typeof(Cat), "Cat")
+                .RegisterSubtype(typeof(Dog), "Dog")
+                .OnUnresolvedSubtype(notifications.Add);
+            if (withFallback)
+            {
+                builder.SetFallbackSubtype(typeof(UnknownAnimal));
+            }
+
+            return new JsonSerializerOptions
+            {
+                Converters = { builder.Build() }
+            };
+        }
+
+        [Test]
+        public void CallbackNotInvokedWhenSubtypeIsResolved()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var options = DiscriminatorOptions(notifications, true);
+
+            var result = JsonSerializer.Deserialize<Animal>("{\"type\":\"Cat\",\"age\":3,\"lives\":7}", options);
+
+            Assert.AreEqual(typeof(Cat), result?.GetType());
+            Assert.AreEqual(0, notifications.Count);
+        }
+
+        [Test]
+        public void CallbackInvokedForUnknownDiscriminatorValue()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var options = DiscriminatorOptions(notifications, true);
+
+            var result = JsonSerializer.Deserialize<Animal>("{\"type\":\"NonExistentType42\",\"age\":3}", options);
+
+            Assert.AreEqual(typeof(UnknownAnimal), result?.GetType());
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(typeof(Animal), notifications[0].ParentType);
+            Assert.AreEqual("type", notifications[0].DiscriminatorPropertyName);
+            Assert.AreEqual("NonExistentType42", notifications[0].DiscriminatorValue);
+            Assert.IsTrue(notifications[0].HasDiscriminator);
+            Assert.AreEqual(typeof(UnknownAnimal), notifications[0].FallbackSubtype);
+        }
+
+        [Test]
+        public void CallbackInvokedForMissingDiscriminator()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var options = DiscriminatorOptions(notifications, true);
+
+            var result = JsonSerializer.Deserialize<Animal>("{\"age\":3}", options);
+
+            Assert.AreEqual(typeof(UnknownAnimal), result?.GetType());
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(typeof(Animal), notifications[0].ParentType);
+            Assert.IsNull(notifications[0].DiscriminatorValue);
+            Assert.IsFalse(notifications[0].HasDiscriminator);
+        }
+
+        [Test]
+        public void CallbackInvokedEvenWithoutFallbackSubtype()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var options = DiscriminatorOptions(notifications, false);
+
+            Assert.Throws<JsonException>(() =>
+                JsonSerializer.Deserialize<Animal>("{\"type\":\"NonExistentType42\"}", options));
+
+            Assert.AreEqual(1, notifications.Count);
+            Assert.IsNull(notifications[0].FallbackSubtype);
+            Assert.AreEqual("NonExistentType42", notifications[0].DiscriminatorValue);
+        }
+
+        [Test]
+        public void CallbackInvokedForEachUnresolvedElementInTree()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var options = new JsonSerializerOptions
+            {
+                Converters =
+                {
+                    JsonSubtypesConverterBuilder
+                        .Of(typeof(IStep), "Type")
+                        .SetFallbackSubtype(typeof(UnknownStepsTrap))
+                        .RegisterSubtype(typeof(RegisteredStep), "RegisteredStep")
+                        .OnUnresolvedSubtype(notifications.Add)
+                        .Build()
+                }
+            };
+
+            var json = "[" +
+                       "{\"Type\":\"NonExistentType42\"}," +
+                       "{\"Type\":\"RegisteredStep\"}," +
+                       "{\"Type\":\"AnotherUnknownType\",\"Steps\":[{\"Type\":\"AlsoUnknown\"}]}" +
+                       "]";
+
+            var result = JsonSerializer.Deserialize<List<IStep>>(json, options);
+
+            Assert.AreEqual(3, result.Count);
+            Assert.IsInstanceOf<UnknownStepsTrap>(result[0]);
+            Assert.IsInstanceOf<RegisteredStep>(result[1]);
+            Assert.IsInstanceOf<UnknownStepsTrap>(result[2]);
+            Assert.IsInstanceOf<UnknownStepsTrap>(result[2].Steps[0]);
+            Assert.AreEqual(3, notifications.Count);
+            Assert.AreEqual("NonExistentType42", notifications[0].DiscriminatorValue);
+            Assert.AreEqual("AnotherUnknownType", notifications[1].DiscriminatorValue);
+            Assert.AreEqual("AlsoUnknown", notifications[2].DiscriminatorValue);
+        }
+
+        [Test]
+        public void CallbackInvokedInPropertyPresenceMode()
+        {
+            var notifications = new List<UnresolvedSubtypeInfo>();
+            var options = new JsonSerializerOptions
+            {
+                Converters =
+                {
+                    JsonSubtypesWithPropertyConverterBuilder
+                        .Of(typeof(Animal))
+                        .RegisterSubtypeWithProperty(typeof(Cat), "catLives")
+                        .RegisterSubtypeWithProperty(typeof(Dog), "canBark")
+                        .SetFallbackSubtype(typeof(UnknownAnimal))
+                        .OnUnresolvedSubtype(notifications.Add)
+                        .Build()
+                }
+            };
+
+            var result = JsonSerializer.Deserialize<Animal>("{\"age\":3}", options);
+
+            Assert.AreEqual(typeof(UnknownAnimal), result?.GetType());
+            Assert.AreEqual(1, notifications.Count);
+            Assert.AreEqual(typeof(Animal), notifications[0].ParentType);
+            Assert.IsNull(notifications[0].DiscriminatorPropertyName);
+            Assert.IsFalse(notifications[0].HasDiscriminator);
+            Assert.AreEqual(typeof(UnknownAnimal), notifications[0].FallbackSubtype);
+        }
+    }
+}

--- a/JsonSubTypes.Text.Json/JsonSubtypes.cs
+++ b/JsonSubTypes.Text.Json/JsonSubtypes.cs
@@ -111,6 +111,7 @@ namespace JsonSubTypes.Text.Json
         private readonly bool _serializeDiscriminatorProperty;
         private readonly bool _addDiscriminatorFirst;
         private readonly Dictionary<Type, object?>? _runtimeTypeToDiscriminator;
+        private readonly Action<UnresolvedSubtypeInfo>? _onUnresolvedSubtype;
 
         public JsonSubtypes()
         {
@@ -128,13 +129,15 @@ namespace JsonSubTypes.Text.Json
             List<TypeWithPropertyMatchingAttributes>? typesByPropertyPresence,
             Type? fallbackType,
             bool serializeDiscriminatorProperty,
-            bool addDiscriminatorFirst) : this(jsonDiscriminatorPropertyName)
+            bool addDiscriminatorFirst,
+            Action<UnresolvedSubtypeInfo>? onUnresolvedSubtype) : this(jsonDiscriminatorPropertyName)
         {
             _subTypeMapping = subTypeMapping;
             _typesByPropertyPresence = typesByPropertyPresence;
             _fallbackType = fallbackType;
             _serializeDiscriminatorProperty = serializeDiscriminatorProperty;
             _addDiscriminatorFirst = addDiscriminatorFirst;
+            _onUnresolvedSubtype = onUnresolvedSubtype;
             if (subTypeMapping != null)
             {
                 _runtimeTypeToDiscriminator = new Dictionary<Type, object?>();
@@ -537,7 +540,42 @@ namespace JsonSubTypes.Text.Json
                 resolvedType = GetTypeFromDiscriminatorValue(jObject, parentType, jsonSerializerOptions);
             }
 
-            return resolvedType ?? GetFallbackSubType(parentType) ?? parentType;
+            if (resolvedType != null)
+            {
+                return resolvedType;
+            }
+
+            Type? fallbackSubtype = GetFallbackSubType(parentType);
+            NotifyUnresolvedSubtype(jObject, parentType, jsonSerializerOptions, fallbackSubtype);
+            return fallbackSubtype ?? parentType;
+        }
+
+        private void NotifyUnresolvedSubtype(JsonDocument jObject, Type parentType,
+            JsonSerializerOptions jsonSerializerOptions, Type? fallbackSubtype)
+        {
+            Action<UnresolvedSubtypeInfo>? onUnresolvedSubtype = _onUnresolvedSubtype;
+            if (onUnresolvedSubtype == null)
+            {
+                return;
+            }
+
+            object? discriminatorValue = null;
+            bool hasDiscriminator = false;
+            if (JsonDiscriminatorPropertyName != null &&
+                TryGetValueInJson(jObject.RootElement, JsonDiscriminatorPropertyName, jsonSerializerOptions,
+                    out JsonElement discriminatorElement))
+            {
+                hasDiscriminator = true;
+                discriminatorValue = discriminatorElement.ValueKind switch
+                {
+                    JsonValueKind.Null => null,
+                    JsonValueKind.String => discriminatorElement.GetString(),
+                    _ => discriminatorElement.ToString()
+                };
+            }
+
+            onUnresolvedSubtype(new UnresolvedSubtypeInfo(parentType, JsonDiscriminatorPropertyName,
+                discriminatorValue, hasDiscriminator, fallbackSubtype));
         }
 
         private Type GetType(JsonDocument jObject, Type parentType, JsonSerializerOptions serializer)

--- a/JsonSubTypes.Text.Json/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes.Text.Json/JsonSubtypesConverterBuilder.cs
@@ -57,11 +57,6 @@ namespace JsonSubTypes.Text.Json
             return SetFallbackSubtype(typeof(T));
         }
 
-        /// <summary>
-        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
-        /// (unknown or missing discriminator value). The callback is invoked on the thread
-        /// performing the deserialization, once per unresolved element.
-        /// </summary>
         public JsonSubtypesConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
         {
             _onUnresolvedSubtype = onUnresolvedSubtype;

--- a/JsonSubTypes.Text.Json/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes.Text.Json/JsonSubtypesConverterBuilder.cs
@@ -17,6 +17,7 @@ namespace JsonSubTypes.Text.Json
         private Type? _fallbackType;
         private bool _serializeDiscriminatorProperty;
         private bool _addDiscriminatorFirst;
+        private Action<UnresolvedSubtypeInfo>? _onUnresolvedSubtype;
 
         private JsonSubtypesConverterBuilder(Type baseType, string discriminatorProperty)
         {
@@ -54,6 +55,17 @@ namespace JsonSubTypes.Text.Json
         public JsonSubtypesConverterBuilder SetFallbackSubtype<T>()
         {
             return SetFallbackSubtype(typeof(T));
+        }
+
+        /// <summary>
+        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
+        /// (unknown or missing discriminator value). The callback is invoked on the thread
+        /// performing the deserialization, once per unresolved element.
+        /// </summary>
+        public JsonSubtypesConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
+        {
+            _onUnresolvedSubtype = onUnresolvedSubtype;
+            return this;
         }
 
         public JsonSubtypesConverterBuilder SerializeDiscriminatorProperty()
@@ -95,13 +107,14 @@ namespace JsonSubTypes.Text.Json
                     typeof(List<TypeWithPropertyMatchingAttributes>),
                     typeof(Type),
                     typeof(bool),
-                    typeof(bool)
+                    typeof(bool),
+                    typeof(Action<UnresolvedSubtypeInfo>)
                 }, null)!;
             return (JsonConverter)constructor.Invoke(
                 new object?[]
                 {
                     _discriminatorProperty, _subTypeMapping, null, _fallbackType,
-                    _serializeDiscriminatorProperty, _addDiscriminatorFirst
+                    _serializeDiscriminatorProperty, _addDiscriminatorFirst, _onUnresolvedSubtype
                 })!;
         }
     }

--- a/JsonSubTypes.Text.Json/JsonSubtypesWithPropertyConverterBuilder.cs
+++ b/JsonSubTypes.Text.Json/JsonSubtypesWithPropertyConverterBuilder.cs
@@ -61,11 +61,6 @@ namespace JsonSubTypes.Text.Json
             return SetFallbackSubtype(typeof(T));
         }
 
-        /// <summary>
-        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
-        /// (no registered property matched the JSON object). The callback is invoked on
-        /// the thread performing the deserialization, once per unresolved element.
-        /// </summary>
         public JsonSubtypesWithPropertyConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
         {
             _onUnresolvedSubtype = onUnresolvedSubtype;

--- a/JsonSubTypes.Text.Json/JsonSubtypesWithPropertyConverterBuilder.cs
+++ b/JsonSubTypes.Text.Json/JsonSubtypesWithPropertyConverterBuilder.cs
@@ -16,6 +16,7 @@ namespace JsonSubTypes.Text.Json
         private readonly Dictionary<string, TypeWithPropertyMatchingAttributes> _types =
             new Dictionary<string, TypeWithPropertyMatchingAttributes>();
         private Type? _fallbackType;
+        private Action<UnresolvedSubtypeInfo>? _onUnresolvedSubtype;
 
         private JsonSubtypesWithPropertyConverterBuilder(Type baseType)
         {
@@ -60,6 +61,17 @@ namespace JsonSubTypes.Text.Json
             return SetFallbackSubtype(typeof(T));
         }
 
+        /// <summary>
+        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
+        /// (no registered property matched the JSON object). The callback is invoked on
+        /// the thread performing the deserialization, once per unresolved element.
+        /// </summary>
+        public JsonSubtypesWithPropertyConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
+        {
+            _onUnresolvedSubtype = onUnresolvedSubtype;
+            return this;
+        }
+
         [RequiresUnreferencedCode("JsonSubTypes.Text.Json uses reflection to create the subtype converter.")]
         [RequiresDynamicCode("JsonSubTypes.Text.Json uses reflection to create the subtype converter.")]
         public JsonConverter Build()
@@ -74,10 +86,11 @@ namespace JsonSubTypes.Text.Json
                     typeof(List<TypeWithPropertyMatchingAttributes>),
                     typeof(Type),
                     typeof(bool),
-                    typeof(bool)
+                    typeof(bool),
+                    typeof(Action<UnresolvedSubtypeInfo>)
                 }, null)!;
             return (JsonConverter)constructor.Invoke(
-                new object?[] { null, null, _types.Values.ToList(), _fallbackType, false, false })!;
+                new object?[] { null, null, _types.Values.ToList(), _fallbackType, false, false, _onUnresolvedSubtype })!;
         }
     }
 }

--- a/JsonSubTypes.Text.Json/UnresolvedSubtypeInfo.cs
+++ b/JsonSubTypes.Text.Json/UnresolvedSubtypeInfo.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace JsonSubTypes.Text.Json
+{
+    /// <summary>
+    /// Describes a JSON object whose subtype could not be resolved by the converter
+    /// (unknown or missing discriminator value, or no matching property in
+    /// property-presence mode).
+    /// </summary>
+    public class UnresolvedSubtypeInfo
+    {
+        /// <summary>Gets the type for which the subtype was resolved.</summary>
+        public Type ParentType { get; }
+
+        /// <summary>
+        /// Gets the name of the discriminator property, or <c>null</c> when the converter
+        /// resolves by property presence.
+        /// </summary>
+        public string? DiscriminatorPropertyName { get; }
+
+        /// <summary>
+        /// Gets the discriminator value read from the JSON object, or <c>null</c> when the
+        /// discriminator property is missing or holds a JSON <c>null</c>.
+        /// </summary>
+        public object? DiscriminatorValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the discriminator property was present in the
+        /// JSON object. Use this to distinguish a missing discriminator from an unknown
+        /// value (<see cref="DiscriminatorValue" /> is <c>null</c> in both cases).
+        /// </summary>
+        public bool HasDiscriminator { get; }
+
+        /// <summary>
+        /// Gets the fallback subtype that will be used for this JSON object, or <c>null</c>
+        /// when no fallback subtype is configured.
+        /// </summary>
+        public Type? FallbackSubtype { get; }
+
+        public UnresolvedSubtypeInfo(Type parentType, string? discriminatorPropertyName, object? discriminatorValue,
+            bool hasDiscriminator, Type? fallbackSubtype)
+        {
+            ParentType = parentType;
+            DiscriminatorPropertyName = discriminatorPropertyName;
+            DiscriminatorValue = discriminatorValue;
+            HasDiscriminator = hasDiscriminator;
+            FallbackSubtype = fallbackSubtype;
+        }
+    }
+}

--- a/JsonSubTypes.Text.Json/UnresolvedSubtypeInfo.cs
+++ b/JsonSubTypes.Text.Json/UnresolvedSubtypeInfo.cs
@@ -2,39 +2,12 @@ using System;
 
 namespace JsonSubTypes.Text.Json
 {
-    /// <summary>
-    /// Describes a JSON object whose subtype could not be resolved by the converter
-    /// (unknown or missing discriminator value, or no matching property in
-    /// property-presence mode).
-    /// </summary>
     public class UnresolvedSubtypeInfo
     {
-        /// <summary>Gets the type for which the subtype was resolved.</summary>
         public Type ParentType { get; }
-
-        /// <summary>
-        /// Gets the name of the discriminator property, or <c>null</c> when the converter
-        /// resolves by property presence.
-        /// </summary>
         public string? DiscriminatorPropertyName { get; }
-
-        /// <summary>
-        /// Gets the discriminator value read from the JSON object, or <c>null</c> when the
-        /// discriminator property is missing or holds a JSON <c>null</c>.
-        /// </summary>
         public object? DiscriminatorValue { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the discriminator property was present in the
-        /// JSON object. Use this to distinguish a missing discriminator from an unknown
-        /// value (<see cref="DiscriminatorValue" /> is <c>null</c> in both cases).
-        /// </summary>
         public bool HasDiscriminator { get; }
-
-        /// <summary>
-        /// Gets the fallback subtype that will be used for this JSON object, or <c>null</c>
-        /// when no fallback subtype is configured.
-        /// </summary>
         public Type? FallbackSubtype { get; }
 
         public UnresolvedSubtypeInfo(Type parentType, string? discriminatorPropertyName, object? discriminatorValue,

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -80,6 +80,8 @@ namespace JsonSubTypes
 
         protected readonly string JsonDiscriminatorPropertyName;
 
+        internal Action<UnresolvedSubtypeInfo> OnUnresolvedSubtype { get; set; }
+
         [ThreadStatic] private static bool _isInsideRead;
 
         [ThreadStatic] private static JsonReader _reader;
@@ -250,7 +252,39 @@ namespace JsonSubTypes
                 resolvedType = GetTypeFromDiscriminatorValue(jObject, parentType, serializer);
             }
 
-            return resolvedType ?? GetFallbackSubType(parentType);
+            if (resolvedType != null)
+            {
+                return resolvedType;
+            }
+
+            Type fallbackSubtype = GetFallbackSubType(parentType);
+            NotifyUnresolvedSubtype(jObject, parentType, fallbackSubtype);
+            return fallbackSubtype;
+        }
+
+        private void NotifyUnresolvedSubtype(JObject jObject, Type parentType, Type fallbackSubtype)
+        {
+            Action<UnresolvedSubtypeInfo> onUnresolvedSubtype = OnUnresolvedSubtype;
+            if (onUnresolvedSubtype == null)
+            {
+                return;
+            }
+
+            object discriminatorValue = null;
+            bool hasDiscriminator = false;
+            if (JsonDiscriminatorPropertyName != null)
+            {
+                JToken discriminatorToken;
+                if (TryGetValueInJson(jObject, JsonDiscriminatorPropertyName, out discriminatorToken) ||
+                    (discriminatorToken = jObject.SelectToken(JsonDiscriminatorPropertyName)) != null)
+                {
+                    hasDiscriminator = true;
+                    discriminatorValue = discriminatorToken.ToObject<object>();
+                }
+            }
+
+            onUnresolvedSubtype(new UnresolvedSubtypeInfo(parentType, JsonDiscriminatorPropertyName,
+                discriminatorValue, hasDiscriminator, fallbackSubtype));
         }
 
         private Type GetType(JObject jObject, Type parentType, JsonSerializer serializer)

--- a/JsonSubTypes/JsonSubtypesByDiscriminatorValueConverter.cs
+++ b/JsonSubTypes/JsonSubtypesByDiscriminatorValueConverter.cs
@@ -39,8 +39,16 @@ namespace JsonSubTypes
         private readonly NullableDictionary<object, Type> _subTypeMapping;
 
         // this constructor is part of the public api since it's protected and this class is public
-       protected internal JsonSubtypesByDiscriminatorValueConverter(Type baseType, string discriminatorProperty,
-            NullableDictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst, Type fallbackType) : base(baseType, discriminatorProperty, fallbackType)
+        protected internal JsonSubtypesByDiscriminatorValueConverter(Type baseType, string discriminatorProperty,
+            NullableDictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst, Type fallbackType)
+            : this(baseType, discriminatorProperty, subTypeMapping, serializeDiscriminatorProperty, addDiscriminatorFirst, fallbackType, null)
+        {
+        }
+
+        // this constructor is part of the public api since it's protected and this class is public
+        protected internal JsonSubtypesByDiscriminatorValueConverter(Type baseType, string discriminatorProperty,
+            NullableDictionary<object, Type> subTypeMapping, bool serializeDiscriminatorProperty, bool addDiscriminatorFirst, Type fallbackType, Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
+            : base(baseType, discriminatorProperty, fallbackType, onUnresolvedSubtype)
         {
             _serializeDiscriminatorProperty = serializeDiscriminatorProperty;
             _subTypeMapping = subTypeMapping;

--- a/JsonSubTypes/JsonSubtypesByPropertyPresenceConverter.cs
+++ b/JsonSubTypes/JsonSubtypesByPropertyPresenceConverter.cs
@@ -7,7 +7,7 @@ namespace JsonSubTypes
     {
         private readonly List<TypeWithPropertyMatchingAttributes> _jsonPropertyName2Type;
 
-        internal JsonSubtypesByPropertyPresenceConverter(Type baseType, List<TypeWithPropertyMatchingAttributes> jsonProperty2Type, Type fallbackType) : base(baseType, fallbackType)
+        internal JsonSubtypesByPropertyPresenceConverter(Type baseType, List<TypeWithPropertyMatchingAttributes> jsonProperty2Type, Type fallbackType, Action<UnresolvedSubtypeInfo> onUnresolvedSubtype) : base(baseType, fallbackType, onUnresolvedSubtype)
         {
             _jsonPropertyName2Type = jsonProperty2Type;
         }

--- a/JsonSubTypes/JsonSubtypesConverter.cs
+++ b/JsonSubTypes/JsonSubtypesConverter.cs
@@ -28,16 +28,26 @@ namespace JsonSubTypes
         private readonly Type _baseType;
         private readonly Type _fallbackType;
 
-        internal JsonSubtypesConverter(Type baseType, Type fallbackType) : base()
+        internal JsonSubtypesConverter(Type baseType, Type fallbackType) : this(baseType, fallbackType, null)
         {
-            _baseType = baseType;
-            _fallbackType = fallbackType;
         }
 
-        internal JsonSubtypesConverter(Type baseType, string jsonDiscriminatorPropertyName, Type fallbackType) : base(jsonDiscriminatorPropertyName)
+        internal JsonSubtypesConverter(Type baseType, string jsonDiscriminatorPropertyName, Type fallbackType) : this(baseType, jsonDiscriminatorPropertyName, fallbackType, null)
+        {
+        }
+
+        internal JsonSubtypesConverter(Type baseType, Type fallbackType, Action<UnresolvedSubtypeInfo> onUnresolvedSubtype) : base()
         {
             _baseType = baseType;
             _fallbackType = fallbackType;
+            OnUnresolvedSubtype = onUnresolvedSubtype;
+        }
+
+        internal JsonSubtypesConverter(Type baseType, string jsonDiscriminatorPropertyName, Type fallbackType, Action<UnresolvedSubtypeInfo> onUnresolvedSubtype) : base(jsonDiscriminatorPropertyName)
+        {
+            _baseType = baseType;
+            _fallbackType = fallbackType;
+            OnUnresolvedSubtype = onUnresolvedSubtype;
         }
 
         internal override Type GetFallbackSubType(Type type)

--- a/JsonSubTypes/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesConverterBuilder.cs
@@ -84,11 +84,6 @@ namespace JsonSubTypes
             return SetFallbackSubtype(typeof(T));
         }
 
-        /// <summary>
-        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
-        /// (unknown or missing discriminator value). The callback is invoked on the thread
-        /// performing the deserialization, once per unresolved element.
-        /// </summary>
         public JsonSubtypesConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
         {
             _onUnresolvedSubtype = onUnresolvedSubtype;

--- a/JsonSubTypes/JsonSubtypesConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesConverterBuilder.cs
@@ -33,6 +33,7 @@ namespace JsonSubTypes
         private bool _serializeDiscriminatorProperty;
         private bool _addDiscriminatorFirst = true;
         private Type _fallbackSubtype;
+        private Action<UnresolvedSubtypeInfo> _onUnresolvedSubtype;
 
         public static JsonSubtypesConverterBuilder Of(Type baseType, string discriminatorProperty)
         {
@@ -83,9 +84,20 @@ namespace JsonSubTypes
             return SetFallbackSubtype(typeof(T));
         }
 
+        /// <summary>
+        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
+        /// (unknown or missing discriminator value). The callback is invoked on the thread
+        /// performing the deserialization, once per unresolved element.
+        /// </summary>
+        public JsonSubtypesConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
+        {
+            _onUnresolvedSubtype = onUnresolvedSubtype;
+            return this;
+        }
+
         public JsonConverter Build()
         {
-            return new JsonSubtypesByDiscriminatorValueConverter(_baseType, _discriminatorProperty, _subTypeMapping, _serializeDiscriminatorProperty, _addDiscriminatorFirst, _fallbackSubtype);
+            return new JsonSubtypesByDiscriminatorValueConverter(_baseType, _discriminatorProperty, _subTypeMapping, _serializeDiscriminatorProperty, _addDiscriminatorFirst, _fallbackSubtype, _onUnresolvedSubtype);
         }
     }
 }

--- a/JsonSubTypes/JsonSubtypesWithPropertyConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesWithPropertyConverterBuilder.cs
@@ -54,11 +54,6 @@ namespace JsonSubTypes
             return SetFallbackSubtype(typeof(T));
         }
 
-        /// <summary>
-        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
-        /// (no registered property matched the JSON object). The callback is invoked on
-        /// the thread performing the deserialization, once per unresolved element.
-        /// </summary>
         public JsonSubtypesWithPropertyConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
         {
             _onUnresolvedSubtype = onUnresolvedSubtype;

--- a/JsonSubTypes/JsonSubtypesWithPropertyConverterBuilder.cs
+++ b/JsonSubTypes/JsonSubtypesWithPropertyConverterBuilder.cs
@@ -10,6 +10,7 @@ namespace JsonSubTypes
         private readonly Type _baseType;
         private readonly Dictionary<string, TypeWithPropertyMatchingAttributes> _subTypeMapping = new Dictionary<string, TypeWithPropertyMatchingAttributes>();
         private Type _fallbackSubtype;
+        private Action<UnresolvedSubtypeInfo> _onUnresolvedSubtype;
 
         private JsonSubtypesWithPropertyConverterBuilder(Type baseType)
         {
@@ -53,9 +54,20 @@ namespace JsonSubTypes
             return SetFallbackSubtype(typeof(T));
         }
 
+        /// <summary>
+        /// Registers a callback invoked when a JSON object's subtype cannot be resolved
+        /// (no registered property matched the JSON object). The callback is invoked on
+        /// the thread performing the deserialization, once per unresolved element.
+        /// </summary>
+        public JsonSubtypesWithPropertyConverterBuilder OnUnresolvedSubtype(Action<UnresolvedSubtypeInfo> onUnresolvedSubtype)
+        {
+            _onUnresolvedSubtype = onUnresolvedSubtype;
+            return this;
+        }
+
         public JsonConverter Build()
         {
-            return new JsonSubtypesByPropertyPresenceConverter(_baseType, _subTypeMapping.Values.ToList(), _fallbackSubtype);
+            return new JsonSubtypesByPropertyPresenceConverter(_baseType, _subTypeMapping.Values.ToList(), _fallbackSubtype, _onUnresolvedSubtype);
         }
     }
 }

--- a/JsonSubTypes/UnresolvedSubtypeInfo.cs
+++ b/JsonSubTypes/UnresolvedSubtypeInfo.cs
@@ -2,39 +2,12 @@ using System;
 
 namespace JsonSubTypes
 {
-    /// <summary>
-    /// Describes a JSON object whose subtype could not be resolved by the converter
-    /// (unknown or missing discriminator value, or no matching property in
-    /// property-presence mode).
-    /// </summary>
     public class UnresolvedSubtypeInfo
     {
-        /// <summary>Gets the type for which the subtype was resolved.</summary>
         public Type ParentType { get; }
-
-        /// <summary>
-        /// Gets the name of the discriminator property, or <c>null</c> when the converter
-        /// resolves by property presence.
-        /// </summary>
         public string DiscriminatorPropertyName { get; }
-
-        /// <summary>
-        /// Gets the discriminator value read from the JSON object, or <c>null</c> when the
-        /// discriminator property is missing or holds a JSON <c>null</c>.
-        /// </summary>
         public object DiscriminatorValue { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the discriminator property was present in the
-        /// JSON object. Use this to distinguish a missing discriminator from an unknown
-        /// value (<see cref="DiscriminatorValue" /> is <c>null</c> in both cases).
-        /// </summary>
         public bool HasDiscriminator { get; }
-
-        /// <summary>
-        /// Gets the fallback subtype that will be used for this JSON object, or <c>null</c>
-        /// when no fallback subtype is configured.
-        /// </summary>
         public Type FallbackSubtype { get; }
 
         public UnresolvedSubtypeInfo(Type parentType, string discriminatorPropertyName, object discriminatorValue,

--- a/JsonSubTypes/UnresolvedSubtypeInfo.cs
+++ b/JsonSubTypes/UnresolvedSubtypeInfo.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace JsonSubTypes
+{
+    /// <summary>
+    /// Describes a JSON object whose subtype could not be resolved by the converter
+    /// (unknown or missing discriminator value, or no matching property in
+    /// property-presence mode).
+    /// </summary>
+    public class UnresolvedSubtypeInfo
+    {
+        /// <summary>Gets the type for which the subtype was resolved.</summary>
+        public Type ParentType { get; }
+
+        /// <summary>
+        /// Gets the name of the discriminator property, or <c>null</c> when the converter
+        /// resolves by property presence.
+        /// </summary>
+        public string DiscriminatorPropertyName { get; }
+
+        /// <summary>
+        /// Gets the discriminator value read from the JSON object, or <c>null</c> when the
+        /// discriminator property is missing or holds a JSON <c>null</c>.
+        /// </summary>
+        public object DiscriminatorValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the discriminator property was present in the
+        /// JSON object. Use this to distinguish a missing discriminator from an unknown
+        /// value (<see cref="DiscriminatorValue" /> is <c>null</c> in both cases).
+        /// </summary>
+        public bool HasDiscriminator { get; }
+
+        /// <summary>
+        /// Gets the fallback subtype that will be used for this JSON object, or <c>null</c>
+        /// when no fallback subtype is configured.
+        /// </summary>
+        public Type FallbackSubtype { get; }
+
+        public UnresolvedSubtypeInfo(Type parentType, string discriminatorPropertyName, object discriminatorValue,
+            bool hasDiscriminator, Type fallbackSubtype)
+        {
+            ParentType = parentType;
+            DiscriminatorPropertyName = discriminatorPropertyName;
+            DiscriminatorValue = discriminatorValue;
+            HasDiscriminator = hasDiscriminator;
+            FallbackSubtype = fallbackSubtype;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -227,6 +227,34 @@ settings.Converters.Add(JsonSubtypesWithPropertyConverterBuilder
     .Build());
 ```
 
+## Detecting unregistered subtypes
+
+When deserializing a polymorphic tree, `OnUnresolvedSubtype` lets you collect every JSON
+object whose subtype could not be resolved (unknown or missing discriminator value, or no
+matching property in property-presence mode), instead of relying on a "trap" fallback type.
+
+```cs
+var notifications = new List<UnresolvedSubtypeInfo>();
+settings.Converters.Add(JsonSubtypesConverterBuilder
+    .Of(typeof(IStep), "Type")
+    .SetFallbackSubtype(typeof(UnknownStepsTrap))
+    .RegisterSubtype(typeof(RegisteredStep), "RegisteredStep")
+    .OnUnresolvedSubtype(notifications.Add)
+    .Build());
+
+var steps = JsonConvert.DeserializeObject<List<IStep>>(json, settings);
+```
+
+The callback is invoked once per unresolved element, on the thread performing the
+deserialization. `UnresolvedSubtypeInfo` carries the parent type, the discriminator property
+name, the discriminator value read from the JSON, a `HasDiscriminator` flag (to distinguish a
+missing discriminator from an unknown value), and the fallback subtype that will be used
+(`null` when none is configured). If you share a converter across threads, the callback is
+invoked from multiple threads and must be thread-safe. The same API is available on
+`JsonSubtypesWithPropertyConverterBuilder` and, for `System.Text.Json`, on
+`JsonSubtypesConverterBuilder`/`JsonSubtypesWithPropertyConverterBuilder` in the
+`JsonSubTypes.Text.Json` namespace.
+
 ## System.Text.Json variant
 
 > **Status: experimental.** The `JsonSubTypes.Text.Json` package is a **release candidate** (`1.0.0-rc.x`) and not yet part of the project's stable offering. The code is fully tested (133 unit tests) and the API is complete, but the stable `1.0.0` release will follow once the package has been exercised in more real-world projects.


### PR DESCRIPTION
Closes #112

## Problem

The reporter of #112 wants to detect, while deserializing a polymorphic tree, every object whose `Type` discriminator is not registered — without throwing on the first mismatch. Today the only way is a "trap" fallback type: its constructor records each unknown `Type` into a static list, which is not thread-safe and requires cleanup after deserialization.

## Fix

Adds `OnUnresolvedSubtype` to all four builders (`JsonSubtypesConverterBuilder` / `JsonSubtypesWithPropertyConverterBuilder`, in both `JsonSubTypes` and `JsonSubTypes.Text.Json`). The callback fires once per JSON element whose subtype cannot be resolved: unknown or missing discriminator value, or no matching property in property-presence mode.

The hook sits at the existing single failure point in both backends (`resolvedType ?? GetFallbackSubType(...)`), so nothing changes when no callback is registered. `UnresolvedSubtypeInfo` exposes the parent type, the discriminator name and value, a `HasDiscriminator` flag (to distinguish a missing discriminator from an unknown value, both otherwise read as `null`) and the fallback subtype that will be used (`null` when none is configured).

## Tests

- `JsonSubTypes.Text.Json.Tests`: 139 pass on net8.0 and net10.0. Six new tests: no callback when the subtype resolves, unknown value, missing discriminator, no fallback configured, one callback per unresolved element in a nested tree, property-presence mode.
- `JsonSubTypes.Tests` (net46): compiles, but the NUnit suite cannot execute under Linux/VSTest, so I validated the same six scenarios through a net8.0 harness against the netstandard2.0 build (all pass).

## Honest notes

- The callback runs on the deserializing thread. A converter shared across threads calls it from several threads, so the callback must be thread-safe; I did not add locking or weak-event machinery.
- `JsonPath` is available in the Newtonsoft backend but not in System.Text.Json (resolution works on a `JsonDocument`, which carries no path), so I omitted it from the info type.
- The callback cannot override the resolved type. That would be a separate custom-type-resolver feature; say so here if you actually need it.

Feedback welcome on the API shape (method name, and what `UnresolvedSubtypeInfo` exposes).