### PR TITLE
Fix SonarCloud scan in the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,10 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3
+        with:
+          args: >
+            -Dsonar.projectKey=manuc66_JsonSubTypes
+            -Dsonar.organization=manuc66-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Problem

The new `analysis` job fails on master with:

```
ERROR You must define the following mandatory properties for 'Unknown': sonar.projectKey, sonar.organization
```

The sonarcloud-github-action needs both values; the migration to GitHub Actions forgot to pass them.

## Fix

Pass `-Dsonar.projectKey=manuc66_JsonSubTypes` and `-Dsonar.organization=manuc66-github` (taken from the historical AppVeyor config) to the action.

## Tests

Cannot be validated locally (the action runs on GitHub). The push to master will re-run the `analysis` job to confirm the scan completes.