### PR TITLE
Newtonsoft converter performance: fast-path resolution and JValue writes

### DIFF
--- a/JsonSubTypes.Benchmarks/BaseAsLeafBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/BaseAsLeafBenchmarks.cs
@@ -37,9 +37,11 @@ namespace JsonSubTypes.Benchmarks
                     .Build());
 
                 _converterJson = JsonSerializer.Serialize<ConvBaseAnimal>(_convBase, _converterOptions);
+                BenchmarkValidation.DeserializeRoundTrips<ConvBaseAnimal, ConvBaseAnimal>(_converterJson, _converterOptions);
             }
 
             _generatedJson = JsonSerializer.Serialize<BaseLeafAnimal>(_generatedBase, _generatedOptions);
+            BenchmarkValidation.DeserializeRoundTrips<BaseLeafAnimal, BaseLeafAnimal>(_generatedJson, _generatedOptions);
         }
 
         [Benchmark]

--- a/JsonSubTypes.Benchmarks/BaseAsLeafBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/BaseAsLeafBenchmarks.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BenchmarkDotNet.Attributes;
+using JsonSubTypes.Text.Json;
+using JsonSubTypes.Text.Json.Aot.Generated;
+using StjBuilder = JsonSubTypes.Text.Json.JsonSubtypesConverterBuilder;
+
+namespace JsonSubTypes.Benchmarks
+{
+    // Base-as-leaf: serializing/deserializing the polymorphic base type itself (not a subtype).
+    // The converter uses its reflection-built base writer/reader on this path (see README), so
+    // this measures that fallback machinery rather than the discriminator round-trip.
+    [MemoryDiagnoser]
+    public class BaseAsLeafBenchmarks
+    {
+        private readonly JsonSerializerOptions? _converterOptions;
+        private readonly JsonSerializerOptions _generatedOptions = new JsonSerializerOptions
+        {
+            TypeInfoResolver = BaseLeafContext.Default,
+            Converters = { JsonSubTypesAotConverters.BaseLeafAnimal }
+        };
+
+        private readonly ConvBaseAnimal _convBase = new ConvBaseAnimal { Age = 3 };
+        private readonly BaseLeafAnimal _generatedBase = new BaseLeafAnimal { Age = 3 };
+
+        private readonly string? _converterJson;
+        private readonly string _generatedJson;
+
+        public BaseAsLeafBenchmarks()
+        {
+            if (JsonSerializer.IsReflectionEnabledByDefault)
+            {
+                _converterOptions = new JsonSerializerOptions();
+                _converterOptions.Converters.Add(StjBuilder.Of<ConvBaseAnimal>("type")
+                    .RegisterSubtype<ConvBaseCat>("cat")
+                    .RegisterSubtype<ConvBaseDog>("dog")
+                    .Build());
+
+                _converterJson = JsonSerializer.Serialize<ConvBaseAnimal>(_convBase, _converterOptions);
+            }
+
+            _generatedJson = JsonSerializer.Serialize<BaseLeafAnimal>(_generatedBase, _generatedOptions);
+        }
+
+        [Benchmark]
+        public string Converter_Serialize() => JsonSerializer.Serialize<ConvBaseAnimal>(_convBase, _converterOptions!);
+
+        [Benchmark]
+        public string Generated_Serialize() => JsonSerializer.Serialize<BaseLeafAnimal>(_generatedBase, _generatedOptions);
+
+        [Benchmark]
+        public ConvBaseAnimal? Converter_Deserialize() => JsonSerializer.Deserialize<ConvBaseAnimal>(_converterJson!, _converterOptions!);
+
+        [Benchmark]
+        public BaseLeafAnimal? Generated_Deserialize() => JsonSerializer.Deserialize<BaseLeafAnimal>(_generatedJson, _generatedOptions);
+    }
+
+    public class ConvBaseAnimal { public int Age { get; set; } }
+    public class ConvBaseCat : ConvBaseAnimal { public int Lives { get; set; } }
+    public class ConvBaseDog : ConvBaseAnimal { public bool CanHunt { get; set; } }
+
+    [JsonSubTypesAotConverter("type")]
+    [KnownSubType(typeof(BaseLeafCat), "cat")]
+    [KnownSubType(typeof(BaseLeafDog), "dog")]
+    public class BaseLeafAnimal { public int Age { get; set; } }
+    public class BaseLeafCat : BaseLeafAnimal { public int Lives { get; set; } }
+    public class BaseLeafDog : BaseLeafAnimal { public bool CanHunt { get; set; } }
+
+    [JsonSerializable(typeof(BaseLeafAnimal))]
+    [JsonSerializable(typeof(BaseLeafCat))]
+    [JsonSerializable(typeof(BaseLeafDog))]
+    public partial class BaseLeafContext : JsonSerializerContext
+    {
+    }
+}

--- a/JsonSubTypes.Benchmarks/BenchmarkValidation.cs
+++ b/JsonSubTypes.Benchmarks/BenchmarkValidation.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+
+namespace JsonSubTypes.Benchmarks
+{
+    // Every benchmark scenario must produce a correct result, otherwise we would be measuring a
+    // broken path. Each benchmark constructor calls these helpers, which fail fast (throw) when
+    // the scenario does not round-trip to the expected subtype with the expected discriminator.
+    public static class BenchmarkValidation
+    {
+        public static string SerializeRoundTrips<T>(T value, string discriminatorName, string discriminatorValue,
+            JsonSerializerOptions options)
+        {
+            string json = JsonSerializer.Serialize(value, options);
+            if (!json.Contains($"\"{discriminatorName}\"") || !json.Contains(discriminatorValue))
+            {
+                throw new InvalidOperationException(
+                    $"Serialize validation failed for {typeof(T).Name}: expected discriminator {discriminatorName}={discriminatorValue} in {json}");
+            }
+            return json;
+        }
+
+        public static void DeserializeRoundTrips<T, TSub>(string json, JsonSerializerOptions options)
+            where TSub : T
+        {
+            T? result = JsonSerializer.Deserialize<T>(json, options);
+            if (result is not TSub)
+            {
+                throw new InvalidOperationException(
+                    $"Deserialize validation failed for {typeof(T).Name}: expected {typeof(TSub).Name} but got {(result == null ? "null" : result.GetType().Name)}");
+            }
+        }
+    }
+}

--- a/JsonSubTypes.Benchmarks/CollectionBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/CollectionBenchmarks.cs
@@ -69,10 +69,13 @@ namespace JsonSubTypes.Benchmarks
                 };
 
                 _converterJson = JsonSerializer.Serialize(_convAnimals, _converterOptions);
+                BenchmarkValidation.DeserializeRoundTrips<List<ColConvAnimal>, List<ColConvAnimal>>(_converterJson, _converterOptions);
                 _resolverJson = JsonSerializer.Serialize(_resAnimals, _resolverOptions);
+                BenchmarkValidation.DeserializeRoundTrips<List<ColResAnimal>, List<ColResAnimal>>(_resolverJson, _resolverOptions);
             }
 
             _generatedJson = JsonSerializer.Serialize(_generatedAnimals, _generatedOptions);
+            BenchmarkValidation.DeserializeRoundTrips<List<ColAnimal>, List<ColAnimal>>(_generatedJson, _generatedOptions);
         }
 
         [Benchmark]

--- a/JsonSubTypes.Benchmarks/NestedHierarchyBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/NestedHierarchyBenchmarks.cs
@@ -40,9 +40,11 @@ namespace JsonSubTypes.Benchmarks
                     .Build());
 
                 _converterJson = JsonSerializer.Serialize<ConvPayload>(_convRun, _converterOptions);
+                BenchmarkValidation.DeserializeRoundTrips<ConvPayload, ConvRun>(_converterJson, _converterOptions);
             }
 
             _generatedJson = JsonSerializer.Serialize<NestedPayload>(_nestedRun, _generatedOptions);
+            BenchmarkValidation.DeserializeRoundTrips<NestedPayload, NestedRun>(_generatedJson, _generatedOptions);
         }
 
         [Benchmark]

--- a/JsonSubTypes.Benchmarks/NewtonsoftBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/NewtonsoftBenchmarks.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Newtonsoft.Json;
@@ -38,6 +39,15 @@ namespace JsonSubTypes.Benchmarks
 
             _singleJson = JsonConvert.SerializeObject(_animal, _settings);
             _collectionJson = JsonConvert.SerializeObject(_animals, _settings);
+
+            if (JsonConvert.DeserializeObject<NwAnimal>(_singleJson, _settings) is not NwCat)
+            {
+                throw new InvalidOperationException("Newtonsoft single round-trip validation failed");
+            }
+            if (JsonConvert.DeserializeObject<List<NwAnimal>>(_collectionJson, _settings) is not List<NwAnimal> { Count: 4 })
+            {
+                throw new InvalidOperationException("Newtonsoft collection round-trip validation failed");
+            }
         }
 
         [Benchmark]

--- a/JsonSubTypes.Benchmarks/NewtonsoftTypeNameHandlingBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/NewtonsoftTypeNameHandlingBenchmarks.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Newtonsoft.Json;
+
+namespace JsonSubTypes.Benchmarks
+{
+    // Newtonsoft's native $type baseline (TypeNameHandling.Auto), the same single-object and
+    // collection scenarios as NewtonsoftBenchmarks, so the discriminator converter can be compared
+    // against Newtonsoft's built-in type-name handling. Auto writes $type only on members whose
+    // declared type is abstract/interface/object (never on a root declared as the base type), so
+    // the single scenario goes through a holder and the base type is abstract here.
+    [MemoryDiagnoser]
+    public class NewtonsoftTypeNameHandlingBenchmarks
+    {
+        private readonly JsonSerializerSettings _settings = new JsonSerializerSettings
+        {
+            TypeNameHandling = TypeNameHandling.Auto
+        };
+
+        private readonly TnHolder _holder = new TnHolder { Animal = new TnCat { Age = 3, Lives = 9 } };
+        private readonly List<TnAnimal> _animals;
+
+        private readonly string _singleJson;
+        private readonly string _collectionJson;
+
+        public NewtonsoftTypeNameHandlingBenchmarks()
+        {
+            _animals = new List<TnAnimal>
+            {
+                new TnCat { Age = 3, Lives = 9 },
+                new TnDog { Age = 5, CanHunt = true },
+                new TnCat { Age = 7, Lives = 7 },
+                new TnDog { Age = 1, CanHunt = false }
+            };
+
+            _singleJson = JsonConvert.SerializeObject(_holder, _settings);
+            _collectionJson = JsonConvert.SerializeObject(_animals, _settings);
+
+            if (JsonConvert.DeserializeObject<TnHolder>(_singleJson, _settings)?.Animal is not TnCat)
+            {
+                throw new InvalidOperationException("TypeNameHandling single round-trip validation failed");
+            }
+            if (JsonConvert.DeserializeObject<List<TnAnimal>>(_collectionJson, _settings) is not List<TnAnimal> { Count: 4 })
+            {
+                throw new InvalidOperationException("TypeNameHandling collection round-trip validation failed");
+            }
+        }
+
+        [Benchmark]
+        public string Single_Serialize() => JsonConvert.SerializeObject(_holder, _settings);
+
+        [Benchmark]
+        public TnHolder? Single_Deserialize() => JsonConvert.DeserializeObject<TnHolder>(_singleJson, _settings);
+
+        [Benchmark]
+        public string Collection_Serialize() => JsonConvert.SerializeObject(_animals, _settings);
+
+        [Benchmark]
+        public List<TnAnimal>? Collection_Deserialize() => JsonConvert.DeserializeObject<List<TnAnimal>>(_collectionJson, _settings);
+    }
+
+    public abstract class TnAnimal { public int Age { get; set; } }
+    public class TnCat : TnAnimal { public int Lives { get; set; } }
+    public class TnDog : TnAnimal { public bool CanHunt { get; set; } }
+    public class TnHolder { public TnAnimal? Animal { get; set; } }
+}

--- a/JsonSubTypes.Benchmarks/Program.cs
+++ b/JsonSubTypes.Benchmarks/Program.cs
@@ -63,11 +63,18 @@ namespace JsonSubTypes.Benchmarks
                         .BuildResolver()
                 };
 
-                _converterJson = JsonSerializer.Serialize<ConvAnimal>(new ConvCat { Age = 3, Lives = 9 }, _converterOptions);
-                _resolverJson = JsonSerializer.Serialize<ResAnimal>(new ResCat { Age = 3, Lives = 9 }, _resolverOptions);
+                _converterJson = BenchmarkValidation.SerializeRoundTrips<ConvAnimal>(new ConvCat { Age = 3, Lives = 9 },
+                    "type", "\"cat\"", _converterOptions);
+                BenchmarkValidation.DeserializeRoundTrips<ConvAnimal, ConvCat>(_converterJson, _converterOptions);
+
+                _resolverJson = BenchmarkValidation.SerializeRoundTrips<ResAnimal>(new ResCat { Age = 3, Lives = 9 },
+                    "type", "\"cat\"", _resolverOptions);
+                BenchmarkValidation.DeserializeRoundTrips<ResAnimal, ResCat>(_resolverJson, _resolverOptions);
             }
 
-            _generatedJson = JsonSerializer.Serialize<BenchAnimal>(new BenchCat { Age = 3, Lives = 9 }, _generatedOptions);
+            _generatedJson = BenchmarkValidation.SerializeRoundTrips<BenchAnimal>(new BenchCat { Age = 3, Lives = 9 },
+                "type", "\"cat\"", _generatedOptions);
+            BenchmarkValidation.DeserializeRoundTrips<BenchAnimal, BenchCat>(_generatedJson, _generatedOptions);
         }
 
         [Benchmark]

--- a/JsonSubTypes.Benchmarks/PropertyPresenceBenchmarks.cs
+++ b/JsonSubTypes.Benchmarks/PropertyPresenceBenchmarks.cs
@@ -35,9 +35,11 @@ namespace JsonSubTypes.Benchmarks
                     .Build());
 
                 _converterJson = JsonSerializer.Serialize<ConvPerson>(_convEmployee, _converterOptions);
+                BenchmarkValidation.DeserializeRoundTrips<ConvPerson, ConvEmployee>(_converterJson, _converterOptions);
             }
 
             _generatedJson = JsonSerializer.Serialize<PresencePerson>(_presenceEmployee, _generatedOptions);
+            BenchmarkValidation.DeserializeRoundTrips<PresencePerson, PresenceEmployee>(_generatedJson, _generatedOptions);
         }
 
         [Benchmark]

--- a/JsonSubTypes.Tests/DiscriminatorOfDifferentKindTests.cs
+++ b/JsonSubTypes.Tests/DiscriminatorOfDifferentKindTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NUnit.Framework;
@@ -218,6 +219,136 @@ namespace JsonSubTypes.Tests
 
                 obj = JsonConvert.DeserializeObject<MainClass>("{\"SubTypeData\":{\"CrazyTypeField\":\"Jack\",\"SubTypeType\": null}}");
                 Assert.AreEqual("Jack", (obj.SubTypeData as NullDiscriminatorClass)?.CrazyTypeField);
+            }
+        }
+
+        [TestFixture]
+        public class DiscriminatorWriteWithCustomConverters
+        {
+            // Covers the discriminator write fast path: string/int discriminators are written as a
+            // plain JValue only when no converter on the serializer handles that type. When a custom
+            // converter applies, the serializer-aware JToken.FromObject path must be used instead,
+            // otherwise the converter would be silently bypassed.
+
+            public class Animal
+            {
+                public int Age { get; set; }
+            }
+
+            public class Cat : Animal
+            {
+                public int Lives { get; set; }
+            }
+
+            public class Dog : Animal
+            {
+                public bool CanHunt { get; set; }
+            }
+
+            private class DoublingIntConverter : JsonConverter
+            {
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    writer.WriteValue(((int)value) * 2);
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    return (int)(long)reader.Value;
+                }
+
+                public override bool CanConvert(Type objectType)
+                {
+                    return objectType == typeof(int);
+                }
+            }
+
+            private class UppercasingStringConverter : JsonConverter
+            {
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    writer.WriteValue(((string)value).ToUpperInvariant());
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    return (string)reader.Value;
+                }
+
+                public override bool CanConvert(Type objectType)
+                {
+                    return objectType == typeof(string);
+                }
+            }
+
+            [Test]
+            public void StringDiscriminatorWithoutConverterUsesFastPath()
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of(typeof(Animal), "type")
+                    .SerializeDiscriminatorProperty()
+                    .RegisterSubtype(typeof(Cat), "cat")
+                    .RegisterSubtype(typeof(Dog), "dog")
+                    .Build());
+
+                var json = JsonConvert.SerializeObject(new Cat { Age = 3, Lives = 9 }, settings);
+
+                StringAssert.Contains("\"type\":\"cat\"", json);
+                StringAssert.Contains("\"Age\":3", json);
+                StringAssert.Contains("\"Lives\":9", json);
+            }
+
+            [Test]
+            public void IntDiscriminatorWithoutConverterUsesFastPath()
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of(typeof(Animal), "type")
+                    .SerializeDiscriminatorProperty()
+                    .RegisterSubtype(typeof(Cat), 1)
+                    .RegisterSubtype(typeof(Dog), 2)
+                    .Build());
+
+                var json = JsonConvert.SerializeObject(new Cat { Age = 3, Lives = 9 }, settings);
+
+                StringAssert.Contains("\"type\":1", json);
+                StringAssert.Contains("\"Age\":3", json);
+                StringAssert.Contains("\"Lives\":9", json);
+            }
+
+            [Test]
+            public void StringDiscriminatorWithConverterKeepsSerializerAwarePath()
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new UppercasingStringConverter());
+                settings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of(typeof(Animal), "type")
+                    .SerializeDiscriminatorProperty()
+                    .RegisterSubtype(typeof(Cat), "cat")
+                    .RegisterSubtype(typeof(Dog), "dog")
+                    .Build());
+
+                var json = JsonConvert.SerializeObject(new Cat { Age = 3, Lives = 9 }, settings);
+
+                StringAssert.Contains("\"type\":\"CAT\"", json);
+            }
+
+            [Test]
+            public void IntDiscriminatorWithConverterKeepsSerializerAwarePath()
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new DoublingIntConverter());
+                settings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of(typeof(Animal), "type")
+                    .SerializeDiscriminatorProperty()
+                    .RegisterSubtype(typeof(Cat), 1)
+                    .RegisterSubtype(typeof(Dog), 2)
+                    .Build());
+
+                var json = JsonConvert.SerializeObject(new Cat { Age = 3, Lives = 9 }, settings);
+
+                StringAssert.Contains("\"type\":2", json);
             }
         }
 

--- a/JsonSubTypes.Tests/DiscriminatorOfDifferentKindTests.cs
+++ b/JsonSubTypes.Tests/DiscriminatorOfDifferentKindTests.cs
@@ -352,5 +352,97 @@ namespace JsonSubTypes.Tests
             }
         }
 
+        [TestFixture]
+        public class DiscriminatorReadWithCustomConverters
+        {
+            // The discriminator lookup fast path (direct string/int read from the JToken) is only
+            // taken when no converter on the serializer handles the key type. These tests pin that
+            // a transforming read converter keeps the serializer-aware path, so the lookup matches
+            // the pre-optimization behavior.
+
+            public class Animal
+            {
+                public int Age { get; set; }
+            }
+
+            public class Cat : Animal
+            {
+                public int Lives { get; set; }
+            }
+
+            public class Dog : Animal
+            {
+                public bool CanHunt { get; set; }
+            }
+
+            private class OffsetIntConverter : JsonConverter
+            {
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    writer.WriteValue(value);
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    return (int)(long)reader.Value + 100;
+                }
+
+                public override bool CanConvert(Type objectType)
+                {
+                    return objectType == typeof(int);
+                }
+            }
+
+            private class PrefixStringConverter : JsonConverter
+            {
+                public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+                {
+                    writer.WriteValue(value);
+                }
+
+                public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+                {
+                    return "x" + (string)reader.Value;
+                }
+
+                public override bool CanConvert(Type objectType)
+                {
+                    return objectType == typeof(string);
+                }
+            }
+
+            [Test]
+            public void IntDiscriminatorHonorsReadConverter()
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new OffsetIntConverter());
+                settings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of(typeof(Animal), "type")
+                    .RegisterSubtype(typeof(Cat), 101)
+                    .RegisterSubtype(typeof(Dog), 202)
+                    .Build());
+
+                var animal = JsonConvert.DeserializeObject<Animal>("{\"type\":1,\"Lives\":9}", settings);
+
+                Assert.IsInstanceOf<Cat>(animal);
+            }
+
+            [Test]
+            public void StringDiscriminatorHonorsReadConverter()
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new PrefixStringConverter());
+                settings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of(typeof(Animal), "type")
+                    .RegisterSubtype(typeof(Cat), "xcat")
+                    .RegisterSubtype(typeof(Dog), "xdog")
+                    .Build());
+
+                var animal = JsonConvert.DeserializeObject<Animal>("{\"type\":\"cat\",\"Lives\":9}", settings);
+
+                Assert.IsInstanceOf<Cat>(animal);
+            }
+        }
+
     }
 }

--- a/JsonSubTypes.Tests/DynamicRegisterTests.cs
+++ b/JsonSubTypes.Tests/DynamicRegisterTests.cs
@@ -615,5 +615,87 @@ namespace JsonSubTypes.Tests
             var e2 = Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(new Cat2(), serializersettings));
             Assert.AreEqual("Impossible to serialize type: JsonSubTypes.Tests.DynamicRegisterTests+Cat2 because there is no registered mapping for the discriminator property", e2.Message);
         }
+
+        [TestFixture]
+        public class TwoResolverProfilesOnSameBaseType
+        {
+            // Two converters registered for the same base type with different discriminator
+            // property names and mappings must not interfere through the shared caches. Each
+            // settings profile resolves its own shape even when used alternately.
+
+            public class Shape
+            {
+                public int Sides { get; set; }
+            }
+
+            public class Circle : Shape
+            {
+                public double Radius { get; set; }
+            }
+
+            public class Square : Shape
+            {
+                public double Side { get; set; }
+            }
+
+            [Test]
+            public void ProfilesWithDifferentDiscriminatorNamesDoNotInterfere()
+            {
+                var kindSettings = new JsonSerializerSettings();
+                kindSettings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("kind")
+                    .RegisterSubtype<Circle>("circle")
+                    .RegisterSubtype<Square>("square")
+                    .Build());
+
+                var shapeSettings = new JsonSerializerSettings();
+                shapeSettings.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("shape")
+                    .RegisterSubtype<Square>("sq")
+                    .RegisterSubtype<Circle>("ci")
+                    .Build());
+
+                // Alternate between the two profiles so any cache collision would surface.
+                for (int i = 0; i < 3; i++)
+                {
+                    var circle = JsonConvert.DeserializeObject<Shape>("{\"kind\":\"circle\",\"Radius\":2.0}", kindSettings);
+                    Assert.IsInstanceOf<Circle>(circle);
+
+                    var square = JsonConvert.DeserializeObject<Shape>("{\"shape\":\"sq\",\"Side\":4.0}", shapeSettings);
+                    Assert.IsInstanceOf<Square>(square);
+
+                    var squareByKind = JsonConvert.DeserializeObject<Shape>("{\"kind\":\"square\",\"Side\":4.0}", kindSettings);
+                    Assert.IsInstanceOf<Square>(squareByKind);
+
+                    var circleByShape = JsonConvert.DeserializeObject<Shape>("{\"shape\":\"ci\",\"Radius\":2.0}", shapeSettings);
+                    Assert.IsInstanceOf<Circle>(circleByShape);
+                }
+            }
+
+            [Test]
+            public void ProfilesWithSameDiscriminatorNameDifferentMappingsDoNotInterfere()
+            {
+                var settingsA = new JsonSerializerSettings();
+                settingsA.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("type")
+                    .RegisterSubtype<Circle>("c")
+                    .Build());
+
+                var settingsB = new JsonSerializerSettings();
+                settingsB.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("type")
+                    .RegisterSubtype<Square>("s")
+                    .Build());
+
+                for (int i = 0; i < 3; i++)
+                {
+                    var circle = JsonConvert.DeserializeObject<Shape>("{\"type\":\"c\",\"Radius\":2.0}", settingsA);
+                    Assert.IsInstanceOf<Circle>(circle);
+
+                    var square = JsonConvert.DeserializeObject<Shape>("{\"type\":\"s\",\"Side\":4.0}", settingsB);
+                    Assert.IsInstanceOf<Square>(square);
+                }
+            }
+        }
     }
 }

--- a/JsonSubTypes.Text.Json.Tests/DiscriminatorOfDifferentKindTests.cs
+++ b/JsonSubTypes.Text.Json.Tests/DiscriminatorOfDifferentKindTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using JsonSubTypes.Text.Json;
 using NUnit.Framework;
 
@@ -181,6 +183,125 @@ namespace JsonSubTypes.Tests
 
                 obj = JsonSerializer.Deserialize<MainClass>("{\"SubTypeData\":{\"CrazyTypeField\":\"Jack\",\"SubTypeType\": null}}");
                 Assert.AreEqual("Jack", (obj.SubTypeData as NullDiscriminatorClass)?.CrazyTypeField);
+            }
+        }
+
+        [TestFixture]
+        public class DiscriminatorWriteWithCustomConverters
+        {
+            // The System.Text.Json write path always serializes the discriminator through
+            // JsonSerializer.Serialize, so converters registered on the options apply. These tests
+            // pin that behavior: a custom converter on the discriminator type must be honored.
+
+            public class Animal
+            {
+                public int Age { get; set; }
+            }
+
+            public class Cat : Animal
+            {
+                public int Lives { get; set; }
+            }
+
+            public class Dog : Animal
+            {
+                public bool CanHunt { get; set; }
+            }
+
+            private class DoublingIntConverter : JsonConverter<int>
+            {
+                public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                {
+                    return reader.GetInt32();
+                }
+
+                public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+                {
+                    writer.WriteNumberValue(value * 2);
+                }
+            }
+
+            private class UppercasingStringConverter : JsonConverter<string>
+            {
+                public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+                {
+                    return reader.GetString();
+                }
+
+                public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+                {
+                    writer.WriteStringValue(value.ToUpperInvariant());
+                }
+            }
+
+            [Test]
+            public void StringDiscriminatorSerializes()
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Animal>("type")
+                    .RegisterSubtype<Cat>("cat")
+                    .RegisterSubtype<Dog>("dog")
+                    .SerializeDiscriminatorProperty()
+                    .Build());
+
+                var json = JsonSerializer.Serialize<Animal>(new Cat { Age = 3, Lives = 9 }, options);
+
+                StringAssert.Contains("\"type\":\"cat\"", json);
+                StringAssert.Contains("\"Age\":3", json);
+                StringAssert.Contains("\"Lives\":9", json);
+            }
+
+            [Test]
+            public void IntDiscriminatorSerializes()
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Animal>("type")
+                    .RegisterSubtype<Cat>(1)
+                    .RegisterSubtype<Dog>(2)
+                    .SerializeDiscriminatorProperty()
+                    .Build());
+
+                var json = JsonSerializer.Serialize<Animal>(new Cat { Age = 3, Lives = 9 }, options);
+
+                StringAssert.Contains("\"type\":1", json);
+                StringAssert.Contains("\"Age\":3", json);
+                StringAssert.Contains("\"Lives\":9", json);
+            }
+
+            [Test]
+            public void StringDiscriminatorHonorsStringConverter()
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new UppercasingStringConverter());
+                options.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Animal>("type")
+                    .RegisterSubtype<Cat>("cat")
+                    .RegisterSubtype<Dog>("dog")
+                    .SerializeDiscriminatorProperty()
+                    .Build());
+
+                var json = JsonSerializer.Serialize<Animal>(new Cat { Age = 3, Lives = 9 }, options);
+
+                StringAssert.Contains("\"type\":\"CAT\"", json);
+            }
+
+            [Test]
+            public void IntDiscriminatorHonorsIntConverter()
+            {
+                var options = new JsonSerializerOptions();
+                options.Converters.Add(new DoublingIntConverter());
+                options.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Animal>("type")
+                    .RegisterSubtype<Cat>(1)
+                    .RegisterSubtype<Dog>(2)
+                    .SerializeDiscriminatorProperty()
+                    .Build());
+
+                var json = JsonSerializer.Serialize<Animal>(new Cat { Age = 3, Lives = 9 }, options);
+
+                StringAssert.Contains("\"type\":2", json);
             }
         }
 

--- a/JsonSubTypes.Text.Json.Tests/DynamicRegisterTests.cs
+++ b/JsonSubTypes.Text.Json.Tests/DynamicRegisterTests.cs
@@ -626,5 +626,86 @@ namespace JsonSubTypes.Tests
 
             Parallel.For(0, 100, index => test());
         }
+
+        [TestFixture]
+        public class TwoResolverProfilesOnSameBaseType
+        {
+            // Two converters registered for the same base type with different discriminator
+            // property names and mappings must not interfere through the shared caches. Each
+            // options profile resolves its own shape even when used alternately.
+
+            public class Shape
+            {
+                public int Sides { get; set; }
+            }
+
+            public class Circle : Shape
+            {
+                public double Radius { get; set; }
+            }
+
+            public class Square : Shape
+            {
+                public double Side { get; set; }
+            }
+
+            [Test]
+            public void ProfilesWithDifferentDiscriminatorNamesDoNotInterfere()
+            {
+                var kindOptions = new JsonSerializerOptions();
+                kindOptions.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("kind")
+                    .RegisterSubtype<Circle>("circle")
+                    .RegisterSubtype<Square>("square")
+                    .Build());
+
+                var shapeOptions = new JsonSerializerOptions();
+                shapeOptions.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("shape")
+                    .RegisterSubtype<Square>("sq")
+                    .RegisterSubtype<Circle>("ci")
+                    .Build());
+
+                for (int i = 0; i < 3; i++)
+                {
+                    var circle = JsonSerializer.Deserialize<Shape>("{\"kind\":\"circle\",\"Radius\":2.0}", kindOptions);
+                    Assert.IsInstanceOf<Circle>(circle);
+
+                    var square = JsonSerializer.Deserialize<Shape>("{\"shape\":\"sq\",\"Side\":4.0}", shapeOptions);
+                    Assert.IsInstanceOf<Square>(square);
+
+                    var squareByKind = JsonSerializer.Deserialize<Shape>("{\"kind\":\"square\",\"Side\":4.0}", kindOptions);
+                    Assert.IsInstanceOf<Square>(squareByKind);
+
+                    var circleByShape = JsonSerializer.Deserialize<Shape>("{\"shape\":\"ci\",\"Radius\":2.0}", shapeOptions);
+                    Assert.IsInstanceOf<Circle>(circleByShape);
+                }
+            }
+
+            [Test]
+            public void ProfilesWithSameDiscriminatorNameDifferentMappingsDoNotInterfere()
+            {
+                var optionsA = new JsonSerializerOptions();
+                optionsA.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("type")
+                    .RegisterSubtype<Circle>("c")
+                    .Build());
+
+                var optionsB = new JsonSerializerOptions();
+                optionsB.Converters.Add(JsonSubtypesConverterBuilder
+                    .Of<Shape>("type")
+                    .RegisterSubtype<Square>("s")
+                    .Build());
+
+                for (int i = 0; i < 3; i++)
+                {
+                    var circle = JsonSerializer.Deserialize<Shape>("{\"type\":\"c\",\"Radius\":2.0}", optionsA);
+                    Assert.IsInstanceOf<Circle>(circle);
+
+                    var square = JsonSerializer.Deserialize<Shape>("{\"type\":\"s\",\"Side\":4.0}", optionsB);
+                    Assert.IsInstanceOf<Square>(square);
+                }
+            }
+        }
     }
 }

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -104,9 +104,13 @@ namespace JsonSubTypes
 
 #if NET35
         private static readonly Dictionary<TypeInfo, IEnumerable<object>> _attributesCache = new Dictionary<TypeInfo, IEnumerable<object>>();
+        private static readonly Dictionary<TypeInfo, NullableDictionary<object, Type>> _subTypeMappingCache = new Dictionary<TypeInfo, NullableDictionary<object, Type>>();
+        private static readonly Dictionary<TypeInfo, List<TypeWithPropertyMatchingAttributes>> _typesByPropertyPresenceCache = new Dictionary<TypeInfo, List<TypeWithPropertyMatchingAttributes>>();
 #else
         private static readonly ConcurrentDictionary<TypeInfo, IEnumerable<object>> _attributesCache = new ConcurrentDictionary<TypeInfo, IEnumerable<object>>();
         private static readonly Func<TypeInfo, IEnumerable<object>> _getCustomAttributes = ti => ti.GetCustomAttributes(false);
+        private static readonly ConcurrentDictionary<TypeInfo, NullableDictionary<object, Type>> _subTypeMappingCache = new ConcurrentDictionary<TypeInfo, NullableDictionary<object, Type>>();
+        private static readonly ConcurrentDictionary<TypeInfo, List<TypeWithPropertyMatchingAttributes>> _typesByPropertyPresenceCache = new ConcurrentDictionary<TypeInfo, List<TypeWithPropertyMatchingAttributes>>();
 #endif
 
         public override bool CanRead
@@ -388,9 +392,26 @@ namespace JsonSubTypes
 
         internal virtual List<TypeWithPropertyMatchingAttributes> GetTypesByPropertyPresence(Type parentType)
         {
-            return GetAttributes<KnownSubTypeWithPropertyAttribute>(ToTypeInfo(parentType))
-                .Select(a => new TypeWithPropertyMatchingAttributes(a.SubType, a.PropertyName, a.StopLookupOnMatch))
-                .ToList();
+            var typeInfo = ToTypeInfo(parentType);
+#if NET35
+            lock (_typesByPropertyPresenceCache)
+            {
+                if (_typesByPropertyPresenceCache.TryGetValue(typeInfo, out var res))
+                    return res;
+
+                res = GetAttributes<KnownSubTypeWithPropertyAttribute>(typeInfo)
+                    .Select(a => new TypeWithPropertyMatchingAttributes(a.SubType, a.PropertyName, a.StopLookupOnMatch))
+                    .ToList();
+                _typesByPropertyPresenceCache.Add(typeInfo, res);
+
+                return res;
+            }
+#else
+            return _typesByPropertyPresenceCache.GetOrAdd(typeInfo,
+                ti => GetAttributes<KnownSubTypeWithPropertyAttribute>(ti)
+                    .Select(a => new TypeWithPropertyMatchingAttributes(a.SubType, a.PropertyName, a.StopLookupOnMatch))
+                    .ToList());
+#endif
         }
 
         private Type GetTypeFromDiscriminatorValue(JObject jObject, Type parentType, JsonSerializer serializer)
@@ -521,9 +542,28 @@ namespace JsonSubTypes
 
         internal virtual NullableDictionary<object, Type> GetSubTypeMapping(Type type)
         {
+            var typeInfo = ToTypeInfo(type);
+#if NET35
+            lock (_subTypeMappingCache)
+            {
+                if (_subTypeMappingCache.TryGetValue(typeInfo, out var res))
+                    return res;
+
+                res = BuildAttributeSubTypeMapping(typeInfo);
+                _subTypeMappingCache.Add(typeInfo, res);
+
+                return res;
+            }
+#else
+            return _subTypeMappingCache.GetOrAdd(typeInfo, BuildAttributeSubTypeMapping);
+#endif
+        }
+
+        private static NullableDictionary<object, Type> BuildAttributeSubTypeMapping(TypeInfo typeInfo)
+        {
             var dictionary = new NullableDictionary<object, Type>();
 
-            GetAttributes<KnownSubTypeAttribute>(ToTypeInfo(type))
+            GetAttributes<KnownSubTypeAttribute>(typeInfo)
                 .ToList()
                 .ForEach(x => dictionary.Add(x.AssociatedValue, x.SubType));
 

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -273,12 +273,25 @@ namespace JsonSubTypes
 
         private Type GetType(JObject jObject, Type parentType, JsonSerializer serializer)
         {
-            Type targetType = parentType;
-            JsonSubtypes lastTypeResolver = null;
-            JsonSubtypes currentTypeResolver = this;
-            var visitedTypes = new HashSet<Type> { targetType };
+            // Single-level resolution is the common case: resolve once with this converter and
+            // only enter the nested walk (converter scan, list, cycle-protection set) when the
+            // resolved type carries its own resolver, i.e. for multi-level hierarchies.
+            Type targetType = ResolveType(jObject, parentType, serializer);
+            if (targetType == null || targetType == parentType)
+            {
+                return targetType ?? parentType;
+            }
 
-            var jsonConverterCollection = serializer.Converters.OfType<JsonSubtypes>().ToList();
+            JsonSubtypes lastTypeResolver = this;
+            JsonSubtypes currentTypeResolver = GetTypeResolver(ToTypeInfo(targetType),
+                serializer.Converters.OfType<JsonSubtypes>().Where(c => c != this));
+            if (currentTypeResolver == null)
+            {
+                return CloseGenericSubtype(targetType, parentType);
+            }
+
+            var visitedTypes = new HashSet<Type> { parentType, targetType };
+            var jsonConverterCollection = serializer.Converters.OfType<JsonSubtypes>().Where(c => c != this).ToList();
             while (currentTypeResolver != null && currentTypeResolver != lastTypeResolver)
             {
                 targetType = currentTypeResolver.ResolveType(jObject, targetType, serializer);
@@ -292,6 +305,11 @@ namespace JsonSubTypes
                 currentTypeResolver = GetTypeResolver(ToTypeInfo(targetType), jsonConverterCollection);
             }
 
+            return CloseGenericSubtype(targetType, parentType);
+        }
+
+        private static Type CloseGenericSubtype(Type targetType, Type parentType)
+        {
             if (targetType != null && ToTypeInfo(targetType).IsGenericTypeDefinition && !ToTypeInfo(parentType).IsGenericTypeDefinition)
             {
                 Type[] parentTypeArguments = GetGenericTypeArguments(parentType).ToArray();
@@ -473,8 +491,7 @@ namespace JsonSubTypes
             var key = typeMapping.NotNullKeys().FirstOrDefault();
             if (key != null)
             {
-                var targetLookupValueType = key.GetType();
-                var lookupValue = discriminatorToken.ToObject(targetLookupValueType, serializer);
+                var lookupValue = GetLookupValue(key, discriminatorToken, serializer);
 
                 if (typeMapping.TryGetValue(lookupValue, out Type targetType))
                 {
@@ -483,6 +500,23 @@ namespace JsonSubTypes
             }
 
             return null;
+        }
+
+        private static object GetLookupValue(object key, JToken discriminatorToken, JsonSerializer serializer)
+        {
+            // Fast path for the dominant string/int mappings: convert the JToken directly
+            // instead of round-tripping through Newtonsoft's full ToObject reflection.
+            if (key is string && discriminatorToken.Type == JTokenType.String)
+            {
+                return discriminatorToken.Value<string>();
+            }
+
+            if (key is int && discriminatorToken.Type == JTokenType.Integer)
+            {
+                return discriminatorToken.Value<int>();
+            }
+
+            return discriminatorToken.ToObject(key.GetType(), serializer);
         }
 
         internal virtual NullableDictionary<object, Type> GetSubTypeMapping(Type type)

--- a/JsonSubTypes/JsonSubtypes.cs
+++ b/JsonSubTypes/JsonSubtypes.cs
@@ -525,16 +525,35 @@ namespace JsonSubTypes
 
         private static object GetLookupValue(object key, JToken discriminatorToken, JsonSerializer serializer)
         {
-            // Fast path for the dominant string/int mappings: convert the JToken directly
-            // instead of round-tripping through Newtonsoft's full ToObject reflection.
-            if (key is string && discriminatorToken.Type == JTokenType.String)
+            // Fast path for the dominant string/int mappings, taken only when no converter
+            // registered on the serializer handles the key type: a custom converter must keep
+            // the serializer-aware ToObject path, mirroring the discriminator write path.
+            if (key is string || key is int)
             {
-                return discriminatorToken.Value<string>();
-            }
+                Type keyType = key.GetType();
+                bool hasConverter = false;
+                IList<JsonConverter> converters = serializer.Converters;
+                for (int i = 0; i < converters.Count; i++)
+                {
+                    if (converters[i].CanConvert(keyType))
+                    {
+                        hasConverter = true;
+                        break;
+                    }
+                }
 
-            if (key is int && discriminatorToken.Type == JTokenType.Integer)
-            {
-                return discriminatorToken.Value<int>();
+                if (!hasConverter)
+                {
+                    if (key is string && discriminatorToken.Type == JTokenType.String)
+                    {
+                        return discriminatorToken.Value<string>();
+                    }
+
+                    if (key is int && discriminatorToken.Type == JTokenType.Integer)
+                    {
+                        return discriminatorToken.Value<int>();
+                    }
+                }
             }
 
             return discriminatorToken.ToObject(key.GetType(), serializer);

--- a/JsonSubTypes/JsonSubtypesByDiscriminatorValueConverter.cs
+++ b/JsonSubTypes/JsonSubtypesByDiscriminatorValueConverter.cs
@@ -138,7 +138,21 @@ namespace JsonSubTypes
                                                          " because there is no registered mapping for the discriminator property");
                 }
             }
-            JToken typeMappingPropertyValue = JToken.FromObject(supportedType, serializer);
+            JToken typeMappingPropertyValue;
+            if ((supportedType is string || supportedType is int) &&
+                !serializer.Converters.Any(c => c.CanConvert(supportedType.GetType())))
+            {
+                // Fast path for the dominant string/int discriminators, taken only when no
+                // converter registered on the serializer handles the discriminator type. In that
+                // case JToken.FromObject would produce a plain JValue anyway, so the output is
+                // identical. A converter for the type (custom int/string converters, ...) keeps
+                // the serializer-aware path below.
+                typeMappingPropertyValue = new JValue(supportedType);
+            }
+            else
+            {
+                typeMappingPropertyValue = JToken.FromObject(supportedType, serializer);
+            }
             if (_addDiscriminatorFirst)
             {
                 jsonObj.AddFirst(new JProperty(JsonDiscriminatorPropertyName, typeMappingPropertyValue));

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -82,10 +82,12 @@ The original `JsonSubTypes` package, through `JsonConvert`. It is a different ru
 
 | Benchmark | Newtonsoft (`JsonSubTypes`) | STJ Converter (`Build()`) |
 | :--- | ---: | ---: |
-| Single serialize | 1.54 µs / 3.07 KB | 1.14 µs / 856 B |
-| Single deserialize | 2.54 µs / 5.26 KB | 1.50 µs / 648 B |
-| Collection serialize (4) | 5.51 µs / 7.53 KB | 4.16 µs / 3288 B |
-| Collection deserialize (4) | 10.21 µs / 12.96 KB | 5.64 µs / 2744 B |
+| Single serialize | 1.41 µs / 2.99 KB | 1.14 µs / 856 B |
+| Single deserialize | 2.03 µs / 4.82 KB | 1.50 µs / 648 B |
+| Collection serialize (4) | 5.25 µs / 7.22 KB | 4.16 µs / 3288 B |
+| Collection deserialize (4) | 8.31 µs / 11.21 KB | 5.64 µs / 2744 B |
+
+The Newtonsoft package received the same fast-path treatment as the STJ converter: single-level type resolution without the multi-level walk, direct string/int discriminator lookup instead of `ToObject` reflection, and a plain `JValue` discriminator write when no converter applies. Its remaining cost is structural — Newtonsoft loads the payload into a `JObject` and re-deserializes through a `JTokenReader`, a double parse we deliberately kept rather than rewrite the read architecture (date parsing, error paths and `Error` events depend on it).
 
 ## Why the engines differ
 


### PR DESCRIPTION
## Problem

The Newtonsoft backend lagged the STJ converter on the same fast-path treatment: it still walked the multi-level hierarchy and resolved discriminators via ToObject reflection on every call.

## Fix

- Fast-path single-level type resolution and direct string/int mapping lookup.
- Write string/int discriminators as a plain JValue, honoring custom converters.
- Cache the attribute-derived subtype mapping and property-presence list per type.
- Test two resolver profiles on the same base type do not interfere.
- Add a base-as-leaf benchmark and validate every benchmark scenario round-trips before measuring.

## Tests

- New cross-backend resolver-isolation test; Newtonsoft and STJ suites pass (net8.0 and net10.0).

## Honest note(s)

- Newtonsoft numbers in PERFORMANCE.md were refreshed after the fast-path work, but the STJ converter column in the same tables is from the pre-streaming state; the follow-up performance refresh PR corrects it.